### PR TITLE
Started new v2 API - Added 2 endpoints - New way to compute chart

### DIFF
--- a/CLASSES/class_API.php
+++ b/CLASSES/class_API.php
@@ -25,6 +25,7 @@
  * @link     http://code.cchits.net Developers Web Site
  * @link     http://gitorious.net/cchits-net Version Control Service
  */
+
 class API
 {
     protected $result = null; // An object for rendering
@@ -483,6 +484,24 @@ class API
                   }
                 }
                 $this->render();
+                break;
+            case 'v2':
+                switch($arrUri['path_items'][2]) {
+                    case 'dates':
+                        $this->result_array = APIv2::getDates();
+                        $this->render();
+                        break;
+                    case 'newchart':
+                        $dates = APIv2::getDates();
+                        $weeks = GeneralFunctions::getValue($arrUri['parameters'], 'weeks', '4', true);
+                        $date = GeneralFunctions::getValue($arrUri['parameters'], 'date', $dates['Today'], true);
+                        $yearweek = APIv2::getYearWeek($date);
+                        $this->result_array = APIv2::getNewChart($yearweek, $weeks);
+                        $this->render();
+                        break;
+                    default:
+                        throw new API_NotApiCall();
+                }
                 break;
             default:
                 throw new API_NotApiCall();

--- a/CLASSES/class_APIv2.php
+++ b/CLASSES/class_APIv2.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * CCHits.net is a website designed to promote Creative Commons Music,
+ * the artists who produce it and anyone or anywhere that plays it.
+ * These files are used to generate the site.
+ *
+ * PHP version 5
+ *
+ * @category Default
+ * @package  CCHitsClass
+ * @author   Yannick Mauray <yannick@frenchguy.ch>
+ * @license  http://www.gnu.org/licenses/agpl.html AGPLv3
+ * @link     http://cchits.net Actual web service
+ * @link     http://code.cchits.net Developers Web Site
+ * @link     http://gitorious.net/cchits-net Version Control Service
+ */
+/**
+ * This class handles all APIv2 calls
+ *
+ * @category Default
+ * @package  UI
+ * @author   Yannick Mauray <yannick@frenchguy.ch>
+ * @license  http://www.gnu.org/licenses/agpl.html AGPLv3
+ * @link     http://cchits.net Actual web service
+ * @link     http://code.cchits.net Developers Web Site
+ * @link     http://gitorious.net/cchits-net Version Control Service
+ */
+class APIv2
+{
+	public static function getDates() {
+		$db = Database::getConnection();
+		try {
+			$sql = "select DATE_FORMAT(NOW(), '%Y-%c-%d') Today, YEARWEEK(NOW(), 3) YearWeek, STR_TO_DATE(CONCAT(YEARWEEK(NOW(), 3),' Monday'), '%x%v %W') Monday, STR_TO_DATE(CONCAT(YEARWEEK(NOW(), 3),' Sunday'), '%x%v %W') Sunday";
+			$query = $db->prepare($sql);
+			$query->execute();
+			if ($query->errorCode() != 0) {
+				throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'error'=>$query->errorInfo()), true), 1);
+			}
+			$data = $query->fetchAll(PDO::FETCH_ASSOC)[0];
+			return $data;
+        } catch(Exception $e) {
+            error_log("SQL Died: " . $e->getMessage());
+            return false;
+        }
+	}
+
+	public static function getYearWeek($date) {
+		$db = Database::getConnection();
+		try {
+			$sql = "SELECT YEARWEEK(STR_TO_DATE('" . $date . "', '%Y-%c-%d'), 3) YearWeek";
+			$query = $db->prepare($sql);
+			$query->execute();
+			if ($query->errorCode() != 0) {
+				throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'error'=>$query->errorInfo()), true), 1);	
+			}
+			$data = $query->fetchAll(PDO::FETCH_ASSOC);
+			return $data[0]['YearWeek'];
+        } catch(Exception $e) {
+            error_log("SQL Died: " . $e->getMessage());
+            return false;
+		}
+	}
+
+	public static function getNewChart($yearweek, $weeks) {
+		$db = Database::getConnection();
+		try {
+			$sql = "SELECT SUM(S.SCORE) intRank, T.* FROM ( SELECT SUM( " . $weeks . " +( YEARWEEK(v.datTimestamp) - " . $yearweek . " ) ) SCORE, v.intTrackID TRACK, YEARWEEK(v.datTimestamp) YEARWEEK FROM votes v WHERE YEARWEEK(v.datTimestamp) <= " . $yearweek . " AND YEARWEEK(v.datTimestamp) > " . $yearweek . " - " . $weeks . " GROUP BY v.intTrackID, YEARWEEK(v.datTimestamp) ORDER BY YEARWEEK DESC, v.intTrackID ASC ) S LEFT JOIN tracks T ON T.intTrackID = S.TRACK GROUP BY S.TRACK ORDER BY intRank DESC";
+			$query = $db->prepare($sql);
+			$query->execute();
+			if ($query->errorCode() != 0) {
+				throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'error'=>$query->errorInfo()), true), 1);	
+			}
+			$data = $query->fetchAll(PDO::FETCH_ASSOC);
+			error_log(json_encode($data));
+			return $data;
+        } catch(Exception $e) {
+            error_log("SQL Died: " . $e->getMessage());
+            return false;
+		}
+	}
+}


### PR DESCRIPTION
A new API is available, with 2 endpoints

/v2/dates - will return today's date, last Monday's, next Sunday's, and also the "yearweek" (year and week of year)
/v2/newchart - will return a weekly chart similar to the one I use for NaPodPoMo. Exemple, with a 4 week decay :
Each votes on week 0 counts for 4 points, then each vote for the week before that count 3 points, etc...