### PR TITLE
Fix for mispronunciation of 'derivatives'

### DIFF
--- a/CLASSES/class_UI.php
+++ b/CLASSES/class_UI.php
@@ -624,7 +624,7 @@ class UI
         $by = "By At-trib-ution";
         $sa = "Share Ae-like";
         $nc = "Non Commercial";
-        $nd = "No Der-i-vat-ives";
+        $nd = "No Der-iv-uh-tivs";
         $sp = "Samp-ling plus";
         $z  = "Zero";
         return self::get_enumTrackLicenseSolve($license, $cc, $by, $sa, $nc, $nd, $sp, $z);


### PR DESCRIPTION
Difference between the two can be tested here: http://tts.speech.cs.cmu.edu:8083 using voice 'cmu_us_clb.flitevox'