### PR TITLE
Fix a weird bug when updating a boolean value

### DIFF
--- a/CLASSES/class_GenericObject.php
+++ b/CLASSES/class_GenericObject.php
@@ -101,7 +101,18 @@ class GenericObject
                         $sql .= ", ";
                     }
                     $sql .= "$change_key = :$change_key";
-                    $values[$change_key] = $this->$change_key;
+                    if ($this->$change_key === true)
+                    {
+                        $values[$change_key] = 1;
+                    }
+                    elseif ($this->change_key === false)
+                    {
+                        $values[$change_key] = 0;
+                    }
+                    else
+                    {
+                        $values[$change_key] = $this->$change_key;
+                    }
                 }
             }
             $full_sql = "UPDATE {$this->strDBTable} SET $sql WHERE $where";


### PR DESCRIPTION
This code worked when `$isNSFW` was true, but not when it was false :
```
function testym($track, $isNSFW) {
        $isNSFW = GenericObject::asBoolean($isNSFW);
        $objTrack = TrackBroker::getTrackByID(UI::getLongNumber($track));
        $objTrack->set_isNSFW($isNSFW);
        $objTrack->write();
    }
```

Booleans are stored as `tinyint(1)`, so in `GenericObject::write()` I test if the value to set a column with is `true`, and change the actual value to `1`. Same with `false` that is changed to `0`. Other values are left unchanged. The above code now works fine.