### PR TITLE
Fixed issue #1 : Need to add NSFW reporting to tracks

### DIFF
--- a/CLASSES/class_GenericObject.php
+++ b/CLASSES/class_GenericObject.php
@@ -105,7 +105,7 @@ class GenericObject
                     {
                         $values[$change_key] = 1;
                     }
-                    elseif ($this->change_key === false)
+                    elseif ($this->$change_key === false)
                     {
                         $values[$change_key] = 0;
                     }

--- a/CLASSES/class_HTML.php
+++ b/CLASSES/class_HTML.php
@@ -134,6 +134,12 @@ class HTML
             case 'vote':
                 $this->vote($object[1], $object[2]);
                 break;
+            case 'report':
+                $this->report($object[1]);
+                break;
+            case 'review':
+                $this->review($object[1], $this->arrUri['parameters']['isNSFW']);
+                break;
             case 'chart':
                 if (isset($this->arrUri['path_items'][1]) and $this->arrUri['path_items'][1] == 'rss') {
                     $this->format = 'rss';
@@ -848,6 +854,58 @@ class HTML
                 UI::SmartyTemplate("vote.html", $this->result);
             }
         }
+    }
+
+    /**
+     * Report a track as not safe for familly or work.
+     *
+     * @param integer $track The reported track
+     *
+     * @return void
+     */
+    function report($track = 0)
+    {
+        if ($track == 0)
+        {
+            return;
+        }
+
+        $objTrack = TrackBroker::getTrackByID(UI::getLongNumber($track));
+
+        if ($objTrack->get_isNSFW())
+        {
+            return;
+        }
+
+        $objTrack->set_needsReview(true);
+        $objTrack->write();
+
+        UI::Redirect("track/" . $track);
+    }
+
+    /**
+     * Review a track : set the isNSFW flag.
+     *
+     * @param integer $track Track to review
+     *
+     * @return void
+     */
+    function review($track = 0, $isNSFW = false)
+    {
+        if ($track == 0)
+        {
+            return;
+        }
+
+        $objTrack = TrackBroker::getTrackByID(UI::getLongNumber($track));
+
+        $isNSFW = GenericObject::asBoolean($isNSFW);
+
+        $objTrack->set_isNSFW($isNSFW);
+        $objTrack->set_needsReview(false);
+        $objTrack->write();
+
+        UI::Redirect("track/" . $track);
     }
 
     /**

--- a/CLASSES/class_TrackBroker.php
+++ b/CLASSES/class_TrackBroker.php
@@ -79,7 +79,7 @@ class TrackBroker
      *
      * @param integer $intTrackID Track ID to search for
      *
-     * @return object|false TrackObject or false if not existing
+     * @return TrackObject|false TrackObject or false if not existing
      */
     public static function getTrackByID($intTrackID = 0)
     {

--- a/CLASSES/class_TrackObject.php
+++ b/CLASSES/class_TrackObject.php
@@ -29,7 +29,7 @@
 class TrackObject extends GenericObject
 {
     // Inherited Properties
-    protected $arrDBItems = array('intArtistID'=>true, 'strTrackName'=>true, 'strTrackNameSounds'=>true, 'strTrackUrl'=>true, 'isNSFW'=>true, 'fileSource'=>true, 'timeLength'=>true, 'md5FileHash'=>true, 'enumTrackLicense'=>true, 'isApproved'=>true, 'intDuplicateID'=>true);
+    protected $arrDBItems = array('intArtistID'=>true, 'strTrackName'=>true, 'strTrackNameSounds'=>true, 'strTrackUrl'=>true, 'isNSFW'=>true, 'needsReview'=>true, 'fileSource'=>true, 'timeLength'=>true, 'md5FileHash'=>true, 'enumTrackLicense'=>true, 'isApproved'=>true, 'intDuplicateID'=>true);
     protected $strDBTable = "tracks";
     protected $strDBKeyCol = "intTrackID";
     // Local Properties
@@ -41,6 +41,7 @@ class TrackObject extends GenericObject
     protected $strTrackUrl = "";
     protected $enumTrackLicense = "";
     protected $isNSFW = false;
+    protected $needsReview = false;
     protected $fileSource = "";
     protected $timeLength = "00:00:00";
     protected $md5FileHash = "";
@@ -73,6 +74,7 @@ class TrackObject extends GenericObject
             $this->strTrackUrl = $pointer->get_strTrackUrl();
             $this->enumTrackLicense = $pointer->get_enumTrackLicense();
             $this->isNSFW = $pointer->get_isNSFW();
+            $this->needsReview = $pointer->get_needsReview();
             $this->fileSource = $pointer->get_fileSource();
             $this->timeLength = $pointer->get_timeLength();
             $this->md5FileHash = $pointer->get_md5FileHash();
@@ -83,6 +85,7 @@ class TrackObject extends GenericObject
         }
         $this->verify_objArtist();
         $this->verify_isNSFW();
+        $this->verify_needsReview();
         $this->verify_isApproved();
         $arrChartData = ChartBroker::getLastSixtyDaysOfChartDataForOneTrack($this->intTrackID);
         if ($arrChartData != false) {
@@ -145,6 +148,9 @@ class TrackObject extends GenericObject
         }
         if (isset($arrUri['parameters']['nsfw'])) {
             $this->set_isNSFW($arrUri['parameters']['nsfw']);
+        }
+        if (isset($arrUri['parameters']['needsReview'])) {
+            $this->set_needsReview($arrUri['parameters']['needsReview']);
         }
         if (isset($arrUri['parameters']['duplicate'])) {
             $this->set_intDuplicateID($arrUri['parameters']['duplicate']);
@@ -308,6 +314,15 @@ class TrackObject extends GenericObject
 
     /**
      * Depending on the value supplied, make sure the actual value in the class
+     * is right for the needsReview value
+     */
+    protected function verify_needsReview()
+    {
+        $this->needsReview = $this->asBoolean($this->needsReview);
+    }
+
+    /**
+     * Depending on the value supplied, make sure the actual value in the class
      * is right for the isApproved value.
      *
      * @return void
@@ -467,9 +482,9 @@ class TrackObject extends GenericObject
      */
     function set_isNSFW($isNSFW = false)
     {
-        if ($isNSFW == "false" || $isNSFW == "0" || $isNSFW == "no") {
+        if ($isNSFW === "false" || $isNSFW === "0" || $isNSFW === "no") {
             $isNSFW = false;
-        } elseif ($isNSFW == "true" || $isNSFW == "1" || $isNSFW == "yes") {
+        } elseif ($isNSFW === "true" || $isNSFW === "1" || $isNSFW === "yes") {
             $isNSFW = true;
         }
         if ($this->isNSFW == true && $isNSFW === false) {
@@ -478,6 +493,29 @@ class TrackObject extends GenericObject
         } elseif ($this->isNSFW == false && $isNSFW === true) {
             $this->isNSFW = true;
             $this->arrChanges['isNSFW'] = true;
+        }
+    }
+
+    /**
+     * Set the needsReview state of the track
+     *
+     * @param boolean $needsReview Whether the track needs a review.
+     *
+     * @return void
+     */
+    function set_needsReview($needsReview = false)
+    {
+        if ($needsReview === "false" || $needsReview === "0" || $needsReview === "no") {
+            $needsReview = false;
+        } elseif ($needsReview === "true" || $needsReview === "1" || $needsReview === "yes") {
+            $needsReview = true;
+        }
+        if ($this->needsReview == true && $needsReview === false) {
+            $this->needsReview = false;
+            $this->arrChanges['needsReview'] = true;
+        } elseif ($this->needsReview == false && $needsReview === true) {
+            $this->needsReview = true;
+            $this->arrChanges['needsReview'] = true;
         }
     }
 
@@ -618,6 +656,7 @@ class TrackObject extends GenericObject
             $this->set_strTrackUrl("");
             $this->set_enumTrackLicense("WIPE");
             $this->set_isNSFW(false);
+            $this->set_needsReview(false);
             $this->set_timeLength("00:00:00");
             $this->set_md5FileHash("");
             $this->set_datDailyShow("");
@@ -780,6 +819,17 @@ class TrackObject extends GenericObject
     {
         return $this->isNSFW;
     }
+
+    /**
+     * Pending review status
+     * 
+     * @return boolean Pending review status
+     */
+    function get_needsReview()
+    {
+        return $this->needsReview;
+    }
+
     /**
      * Filename
      *

--- a/CSS/cchits-extra.css
+++ b/CSS/cchits-extra.css
@@ -96,6 +96,12 @@ a:hover {
     padding: 5px 0;
 }
 
+.chart-track a:hover {
+    background-color: inherit;
+    color: inherit;
+    border-bottom: 1px solid #404040;
+}
+
 .chart-position-current {
     font-size: 2.9rem;
     margin: -.5rem 0;

--- a/TEMPLATES/Source/frontpage.html.tpl
+++ b/TEMPLATES/Source/frontpage.html.tpl
@@ -79,7 +79,7 @@
 							</div>
 							<div class="col-8 col-sm-8 col-md-8 col-lg-4 col-xl-4 chart-info">
 								<div class="chart-track-title">
-									{$track.strTrackName}
+									<a href="{$baseURL}track/{$track.intTrackID}">{$track.strTrackName}</a>
 								</div>
 								<div class="chart-track-artist">
 									{$track.strArtistName}

--- a/TEMPLATES/Source/track.html.tpl
+++ b/TEMPLATES/Source/track.html.tpl
@@ -22,6 +22,26 @@
 		<form action="{$baseURL}vote/{$track.intTrackID}?go" method="post">
   			<input type="submit" name="go" value="I like this track!" />
 		</form>
+{if not $track.isNSFW}
+{if not $track.needsReview}
+		<form action="{$baseURL}report/{$track.intTrackID}?go" method="post">
+			<input type="submit" name="go" value="Report this track as not safe for familly or work" />
+		</form>
+{else}
+		<div><b style="color: red">This track has been reported as not safe for familly or work, it will be reviewed by a moderator.</b></div>
+{if $user.isAdmin}
+		<br/>
+		<form style="color: blue;" action="{$baseURL}review/{$track.intTrackID}?go" method="post">
+			<b>
+			Is this track safe for familly or work ?
+			<input type="radio" name="isNSFW" value="no"> Yes
+			<input type="radio" name="isNSFW" value="yes" checked> No
+			<input type="submit" name="go" value="Review this track" />
+			</b>
+		</form>
+{/if}
+{/if}
+{/if}
 		{include file="track_detail.tpl"}
 	</body>
 	<script type="text/javascript">

--- a/TEMPLATES/Source/track.html.tpl
+++ b/TEMPLATES/Source/track.html.tpl
@@ -25,15 +25,15 @@
 {if not $track.isNSFW}
 {if not $track.needsReview}
 		<form action="{$baseURL}report/{$track.intTrackID}?go" method="post">
-			<input type="submit" name="go" value="Report this track as not safe for familly or work" />
+			<input type="submit" name="go" value="Report this track as not safe for family or work" />
 		</form>
 {else}
-		<div><b style="color: red">This track has been reported as not safe for familly or work, it will be reviewed by a moderator.</b></div>
+		<div><b style="color: red">This track has been reported as not safe for family or work, it will be reviewed by a moderator.</b></div>
 {if $user.isAdmin}
 		<br/>
 		<form style="color: blue;" action="{$baseURL}review/{$track.intTrackID}?go" method="post">
 			<b>
-			Is this track safe for familly or work ?
+			Is this track safe for family or work ?
 			<input type="radio" name="isNSFW" value="no"> Yes
 			<input type="radio" name="isNSFW" value="yes" checked> No
 			<input type="submit" name="go" value="Review this track" />


### PR DESCRIPTION
For each track for which `isNSFW` is not set, a button will appear to "Report this track as not safe for family or work".
Pushing this button will set the `needsReview` flag for that track, and replace the report button with a message : "This track has been reported as not safe for family or work, it will be reviewed by a moderator."
Site admins also see a message asking "Is this track safe for family or work ?", with two options, "yes" and "no" (checked by default), and a button to "Review the track".
Pressing that button clears the `needsReview` flag and sets or clears the `isNSFW` flag depending on the admin's choice.

**CAUTION** : prior to (or just after) merging this pull request, the following SQL patch needs to be applied :
```sql
ALTER TABLE `tracks` 
ADD `needsReview` TINYINT(1) NOT NULL DEFAULT '0' AFTER `isNSFW`, 
ADD INDEX `idx_needsReview` (`needsReview`);
```

**NOTE** : A cron job will need to be set to send an email to admins to remind them of the pending reviews.
