### PR TITLE
Fixed : coding standards compatible with modern PHPCS

### DIFF
--- a/.phpcs/CCHits/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/.phpcs/CCHits/Sniffs/Classes/ClassDeclarationSniff.php
@@ -1,34 +1,18 @@
 <?php
 /**
- * Class Declaration Test.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ClassDeclarationSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-/**
- * Class Declaration Test.
- *
  * Checks the declaration of the class is correct.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassDeclarationSniff implements Sniff
 {
 
 
@@ -39,10 +23,11 @@ class CCHits_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sni
      */
     public function register()
     {
-        return array(
-                T_CLASS,
-                T_INTERFACE,
-               );
+        return [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+        ];
 
     }//end register()
 
@@ -50,16 +35,16 @@ class CCHits_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sni
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param integer              $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param integer                     $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
-        $errorData = array($tokens[$stackPtr]['content']);
+        $errorData = [strtolower($tokens[$stackPtr]['content'])];
 
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             $error = 'Possible parse error: %s missing opening or closing brace';
@@ -72,41 +57,87 @@ class CCHits_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sni
         $classLine   = $tokens[$lastContent]['line'];
         $braceLine   = $tokens[$curlyBrace]['line'];
         if ($braceLine === $classLine) {
+            $phpcsFile->recordMetric($stackPtr, 'Class opening brace placement', 'same line');
             $error = 'Opening brace of a %s must be on the line after the definition';
-            $phpcsFile->addError($error, $curlyBrace, 'OpenBraceNewLine', $errorData);
+            $fix   = $phpcsFile->addFixableError($error, $curlyBrace, 'OpenBraceNewLine', $errorData);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                if ($tokens[($curlyBrace - 1)]['code'] === T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken(($curlyBrace - 1), '');
+                }
+
+                $phpcsFile->fixer->addNewlineBefore($curlyBrace);
+                $phpcsFile->fixer->endChangeset();
+            }
+
             return;
-        } else if ($braceLine > ($classLine + 1)) {
-            $error = 'Opening brace of a %s must be on the line following the %s declaration; found %s line(s)';
-            $data  = array(
-                      $tokens[$stackPtr]['content'],
-                      $tokens[$stackPtr]['content'],
-                      ($braceLine - $classLine - 1),
-                     );
-            $phpcsFile->addError($error, $curlyBrace, 'OpenBraceWrongLine', $data);
-            return;
-        }
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Class opening brace placement', 'new line');
+
+            if ($braceLine > ($classLine + 1)) {
+                $error = 'Opening brace of a %s must be on the line following the %s declaration; found %s line(s)';
+                $data  = [
+                    $tokens[$stackPtr]['content'],
+                    $tokens[$stackPtr]['content'],
+                    ($braceLine - $classLine - 1),
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $curlyBrace, 'OpenBraceWrongLine', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($curlyBrace - 1); $i > $lastContent; $i--) {
+                        if ($tokens[$i]['line'] === ($tokens[$curlyBrace]['line'] + 1)) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+
+                return;
+            }//end if
+        }//end if
 
         if ($tokens[($curlyBrace + 1)]['content'] !== $phpcsFile->eolChar) {
             $error = 'Opening %s brace must be on a line by itself';
-            $phpcsFile->addError($error, $curlyBrace, 'OpenBraceNotAlone', $errorData);
+            $fix   = $phpcsFile->addFixableError($error, $curlyBrace, 'OpenBraceNotAlone', $errorData);
+            if ($fix === true) {
+                $phpcsFile->fixer->addNewline($curlyBrace);
+            }
         }
 
         if ($tokens[($curlyBrace - 1)]['code'] === T_WHITESPACE) {
             $prevContent = $tokens[($curlyBrace - 1)]['content'];
-            if ($prevContent !== $phpcsFile->eolChar) {
+            if ($prevContent === $phpcsFile->eolChar) {
+                $spaces = 0;
+            } else {
                 $blankSpace = substr($prevContent, strpos($prevContent, $phpcsFile->eolChar));
                 $spaces     = strlen($blankSpace);
-                if ($spaces !== 0) {
-                    $error = 'Expected 0 spaces before opening brace; %s found';
-                    $data  = array($spaces);
-                    $phpcsFile->addError($error, $curlyBrace, 'SpaceBeforeBrace', $data);
+            }
+
+            $first    = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);
+            $expected = ($tokens[$first]['column'] - 1);
+            if ($spaces !== $expected) {
+                $error = 'Expected %s spaces before opening brace; %s found';
+                $data  = [
+                    $expected,
+                    $spaces,
+                ];
+
+                $fix = $phpcsFile->addFixableError($error, $curlyBrace, 'SpaceBeforeBrace', $data);
+                if ($fix === true) {
+                    $indent = str_repeat(' ', $expected);
+                    if ($spaces === 0) {
+                        $phpcsFile->fixer->addContentBefore($curlyBrace, $indent);
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($curlyBrace - 1), $indent);
+                    }
                 }
             }
-        }
+        }//end if
 
     }//end process()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Commenting/ClassCommentSniff.php
+++ b/.phpcs/CCHits/Sniffs/Commenting/ClassCommentSniff.php
@@ -2,52 +2,17 @@
 /**
  * Parses and verifies the doc comments for classes.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ClassCommentSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
-    $error = 'Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Commenting;
 
-if (class_exists('CCHits_Sniffs_Commenting_FileCommentSniff', true) === false) {
-    $error = 'Class CCHits_Sniffs_Commenting_FileCommentSniff not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
-/**
- * Parses and verifies the doc comments for classes.
- *
- * Verifies that :
- * <ul>
- *  <li>A doc comment exists.</li>
- *  <li>There is a blank newline after the short description.</li>
- *  <li>There is a blank newline between the long and short description.</li>
- *  <li>There is a blank newline between the long description and tags.</li>
- *  <li>Check the order of the tags.</li>
- *  <li>Check the indentation of each tag.</li>
- *  <li>Check required and optional tags and the format of their content.</li>
- * </ul>
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Commenting_ClassCommentSniff extends CCHits_Sniffs_Commenting_FileCommentSniff
+class ClassCommentSniff extends FileCommentSniff
 {
 
 
@@ -58,10 +23,11 @@ class CCHits_Sniffs_Commenting_ClassCommentSniff extends CCHits_Sniffs_Commentin
      */
     public function register()
     {
-        return array(
-                T_CLASS,
-                T_INTERFACE,
-               );
+        return [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+        ];
 
     }//end register()
 
@@ -69,136 +35,41 @@ class CCHits_Sniffs_Commenting_ClassCommentSniff extends CCHits_Sniffs_Commentin
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $this->currentFile = $phpcsFile;
 
         $tokens    = $phpcsFile->getTokens();
         $type      = strtolower($tokens[$stackPtr]['content']);
-        $errorData = array($type);
-        $find      = array(
-                      T_ABSTRACT,
-                      T_WHITESPACE,
-                      T_FINAL,
-                     );
+        $errorData = [$type];
 
-        // Extract the class comment docblock.
+        $find   = Tokens::$methodPrefixes;
+        $find[] = T_WHITESPACE;
+
         $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
-
-        if ($commentEnd !== false && $tokens[$commentEnd]['code'] === T_COMMENT) {
-            $error = 'You must use "/**" style comments for a %s comment';
-            $phpcsFile->addError($error, $stackPtr, 'WrongStyle', $errorData);
-            return;
-        } else if ($commentEnd === false
-            || $tokens[$commentEnd]['code'] !== T_DOC_COMMENT
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
             $phpcsFile->addError('Missing %s doc comment', $stackPtr, 'Missing', $errorData);
+            $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'no');
             return;
         }
 
-        $commentStart = ($phpcsFile->findPrevious(T_DOC_COMMENT, ($commentEnd - 1), null, true) + 1);
-        $commentNext  = $phpcsFile->findPrevious(T_WHITESPACE, ($commentEnd + 1), $stackPtr, false, $phpcsFile->eolChar);
+        $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'yes');
 
-        // Distinguish file and class comment.
-        $prevClassToken = $phpcsFile->findPrevious(T_CLASS, ($stackPtr - 1));
-        if ($prevClassToken === false) {
-            // This is the first class token in this file, need extra checks.
-            $prevNonComment = $phpcsFile->findPrevious(T_DOC_COMMENT, ($commentStart - 1), null, true);
-            if ($prevNonComment !== false) {
-                $prevComment = $phpcsFile->findPrevious(T_DOC_COMMENT, ($prevNonComment - 1));
-                if ($prevComment === false) {
-                    // There is only 1 doc comment between open tag and class token.
-                    $newlineToken = $phpcsFile->findNext(T_WHITESPACE, ($commentEnd + 1), $stackPtr, false, $phpcsFile->eolChar);
-                    if ($newlineToken !== false) {
-                        $newlineToken = $phpcsFile->findNext(
-                            T_WHITESPACE,
-                            ($newlineToken + 1),
-                            $stackPtr,
-                            false,
-                            $phpcsFile->eolChar
-                        );
-
-                        if ($newlineToken !== false) {
-                            // Blank line between the class and the doc block.
-                            // The doc block is most likely a file comment.
-                            $error = 'Missing %s doc comment';
-                            $phpcsFile->addError($error, ($stackPtr + 1), 'Missing', $errorData);
-                            return;
-                        }
-                    }//end if
-                }//end if
-            }//end if
-        }//end if
-
-        $comment = $phpcsFile->getTokensAsString(
-            $commentStart,
-            ($commentEnd - $commentStart + 1)
-        );
-
-        // Parse the class comment.docblock.
-        try {
-            $this->commentParser = new PHP_CodeSniffer_CommentParser_ClassCommentParser($comment, $phpcsFile);
-            $this->commentParser->parse();
-        } catch (PHP_CodeSniffer_CommentParser_ParserException $e) {
-            $line = ($e->getLineWithinComment() + $commentStart);
-            $phpcsFile->addError($e->getMessage(), $line, 'FailedParse');
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $phpcsFile->addError('You must use "/**" style comments for a %s comment', $stackPtr, 'WrongStyle', $errorData);
             return;
-        }
-
-        $comment = $this->commentParser->getComment();
-        if (is_null($comment) === true) {
-            $error = 'Doc comment is empty for %s';
-            $phpcsFile->addError($error, $commentStart, 'Empty', $errorData);
-            return;
-        }
-
-        // No extra newline before short description.
-        $short        = $comment->getShortComment();
-        $newlineCount = 0;
-        $newlineSpan  = strspn($short, $phpcsFile->eolChar);
-        if ($short !== '' && $newlineSpan > 0) {
-            $error = 'Extra newline(s) found before %s comment short description';
-            $phpcsFile->addError($error, ($commentStart + 1), 'SpacingBeforeShort', $errorData);
-        }
-
-        $newlineCount = (substr_count($short, $phpcsFile->eolChar) + 1);
-
-        // Exactly one blank line between short and long description.
-        $long = $comment->getLongComment();
-        if (empty($long) === false) {
-            $between        = $comment->getWhiteSpaceBetween();
-            $newlineBetween = substr_count($between, $phpcsFile->eolChar);
-            if ($newlineBetween !== 2) {
-                $error = 'There must be exactly one blank line between descriptions in %s comments';
-                $phpcsFile->addError($error, ($commentStart + $newlineCount + 1), 'SpacingAfterShort', $errorData);
-            }
-
-            $newlineCount += $newlineBetween;
-        }
-
-        // Exactly one blank line before tags.
-        $tags = $this->commentParser->getTagOrders();
-        if (count($tags) > 1) {
-            $newlineSpan = $comment->getNewlineAfter();
-            if ($newlineSpan !== 2) {
-                $error = 'There must be exactly one blank line before the tags in %s comments';
-                if ($long !== '') {
-                    $newlineCount += (substr_count($long, $phpcsFile->eolChar) - $newlineSpan + 1);
-                }
-
-                $phpcsFile->addError($error, ($commentStart + $newlineCount), 'SpacingBeforeTags', $errorData);
-                $short = rtrim($short, $phpcsFile->eolChar.' ');
-            }
         }
 
         // Check each tag.
-        $this->processTags($commentStart, $commentEnd);
+        $this->processTags($phpcsFile, $stackPtr, $tokens[$commentEnd]['comment_opener']);
 
     }//end process()
 
@@ -206,23 +77,25 @@ class CCHits_Sniffs_Commenting_ClassCommentSniff extends CCHits_Sniffs_Commentin
     /**
      * Process the version tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processVersion($errorPos)
+    protected function processVersion($phpcsFile, array $tags)
     {
-        $version = $this->commentParser->getVersion();
-        if ($version !== null) {
-            $content = $version->getContent();
-            $matches = array();
-            if (empty($content) === true) {
-                $error = 'Content missing for @version tag in doc comment';
-                $this->currentFile->addError($error, $errorPos, 'EmptyVersion');
-            } else if ((strstr($content, 'Release:') === false)) {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            if ((strstr($content, 'Release:') === false)) {
                 $error = 'Invalid version "%s" in doc comment; consider "Release: <package_version>" instead';
-                $data  = array($content);
-                $this->currentFile->addWarning($error, $errorPos, 'InvalidVersion', $data);
+                $data  = [$content];
+                $phpcsFile->addWarning($error, $tag, 'InvalidVersion', $data);
             }
         }
 
@@ -230,5 +103,3 @@ class CCHits_Sniffs_Commenting_ClassCommentSniff extends CCHits_Sniffs_Commentin
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Commenting/FileCommentSniff.php
+++ b/.phpcs/CCHits/Sniffs/Commenting/FileCommentSniff.php
@@ -2,126 +2,71 @@
 /**
  * Parses and verifies the doc comments for files.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: FileCommentSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found');
-}
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Commenting;
 
-/**
- * Parses and verifies the doc comments for files.
- *
- * Verifies that :
- * <ul>
- *  <li>A doc comment exists.</li>
- *  <li>There is a blank newline after the short description.</li>
- *  <li>There is a blank newline between the long and short description.</li>
- *  <li>There is a blank newline between the long description and tags.</li>
- *  <li>A PHP version is specified.</li>
- *  <li>Check the order of the tags.</li>
- *  <li>Check the indentation of each tag.</li>
- *  <li>Check required and optional tags and the format of their content.</li>
- * </ul>
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Common;
 
-class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
+class FileCommentSniff implements Sniff
 {
-
-    /**
-     * The header comment parser for the current file.
-     *
-     * @var PHP_CodeSniffer_Comment_Parser_ClassCommentParser
-     */
-    protected $commentParser = null;
-
-    /**
-     * The current PHP_CodeSniffer_File object we are processing.
-     *
-     * @var PHP_CodeSniffer_File
-     */
-    protected $currentFile = null;
 
     /**
      * Tags in correct order and related info.
      *
      * @var array
      */
-    protected $tags = array(
-                       'category'   => array(
-                                        'required'       => true,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'precedes @package',
-                                       ),
-                       'package'    => array(
-                                        'required'       => true,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @category',
-                                       ),
-                       'subpackage' => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @package',
-                                       ),
-                       'author'     => array(
-                                        'required'       => true,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'follows @subpackage (if used) or @package',
-                                       ),
-                       'copyright'  => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'follows @author',
-                                       ),
-                       'license'    => array(
-                                        'required'       => true,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @copyright (if used) or @author',
-                                       ),
-                       'version'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @license',
-                                       ),
-                       'link'       => array(
-                                        'required'       => true,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'follows @version',
-                                       ),
-                       'see'        => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'follows @link',
-                                       ),
-                       'since'      => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @see (if used) or @link',
-                                       ),
-                       'deprecated' => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'follows @since (if used) or @see (if used) or @link',
-                                       ),
-                );
+    protected $tags = [
+        '@category'   => [
+            'required'       => true,
+            'allow_multiple' => false,
+        ],
+        '@package'    => [
+            'required'       => true,
+            'allow_multiple' => false,
+        ],
+        '@subpackage' => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@author'     => [
+            'required'       => true,
+            'allow_multiple' => true,
+        ],
+        '@copyright'  => [
+            'required'       => false,
+            'allow_multiple' => true,
+        ],
+        '@license'    => [
+            'required'       => true,
+            'allow_multiple' => false,
+        ],
+        '@version'    => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@link'       => [
+            'required'       => true,
+            'allow_multiple' => true,
+        ],
+        '@see'        => [
+            'required'       => false,
+            'allow_multiple' => true,
+        ],
+        '@since'      => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@deprecated' => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+    ];
 
 
     /**
@@ -131,7 +76,7 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
      */
     public function register()
     {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
 
     }//end register()
 
@@ -139,34 +84,23 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
-        $this->currentFile = $phpcsFile;
-
-        // We are only interested if this is the first open tag.
-        if ($stackPtr !== 0) {
-            if ($phpcsFile->findPrevious(T_OPEN_TAG, ($stackPtr - 1)) !== false) {
-                return;
-            }
-        }
-
         $tokens = $phpcsFile->getTokens();
 
         // Find the next non whitespace token.
-        $commentStart
-            = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $commentStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
 
         // Allow declare() statements at the top of the file.
         if ($tokens[$commentStart]['code'] === T_DECLARE) {
-            $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($commentStart + 1));
-            $commentStart
-                = $phpcsFile->findNext(T_WHITESPACE, ($semicolon + 1), null, true);
+            $semicolon    = $phpcsFile->findNext(T_SEMICOLON, ($commentStart + 1));
+            $commentStart = $phpcsFile->findNext(T_WHITESPACE, ($semicolon + 1), null, true);
         }
 
         // Ignore vim header.
@@ -188,389 +122,217 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 
         if ($tokens[$commentStart]['code'] === T_CLOSE_TAG) {
             // We are only interested if this is the first open tag.
-            return;
+            return ($phpcsFile->numTokens + 1);
         } else if ($tokens[$commentStart]['code'] === T_COMMENT) {
             $error = 'You must use "/**" style comments for a file comment';
             $phpcsFile->addError($error, $errorToken, 'WrongStyle');
-            return;
+            $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'yes');
+            return ($phpcsFile->numTokens + 1);
         } else if ($commentStart === false
-            || $tokens[$commentStart]['code'] !== T_DOC_COMMENT
+            || $tokens[$commentStart]['code'] !== T_DOC_COMMENT_OPEN_TAG
         ) {
             $phpcsFile->addError('Missing file doc comment', $errorToken, 'Missing');
-            return;
-        } else {
+            $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'no');
+            return ($phpcsFile->numTokens + 1);
+        }
 
-            // Extract the header comment docblock.
-            $commentEnd = $phpcsFile->findNext(
-                T_DOC_COMMENT,
-                ($commentStart + 1),
-                null,
-                true
-            );
+        $commentEnd = $tokens[$commentStart]['comment_closer'];
 
-            $commentEnd--;
+        $nextToken = $phpcsFile->findNext(
+            T_WHITESPACE,
+            ($commentEnd + 1),
+            null,
+            true
+        );
 
-            // Check if there is only 1 doc comment between the
-            // open tag and class token.
-            $nextToken   = array(
-                            T_ABSTRACT,
-                            T_CLASS,
-                            T_FUNCTION,
-                            T_DOC_COMMENT,
-                           );
+        $ignore = [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+            T_FUNCTION,
+            T_CLOSURE,
+            T_PUBLIC,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_FINAL,
+            T_STATIC,
+            T_ABSTRACT,
+            T_CONST,
+            T_PROPERTY,
+        ];
 
-            $commentNext = $phpcsFile->findNext($nextToken, ($commentEnd + 1));
-            if ($commentNext !== false
-                && $tokens[$commentNext]['code'] !== T_DOC_COMMENT
+        if (in_array($tokens[$nextToken]['code'], $ignore) === true) {
+            $phpcsFile->addError('Missing file doc comment', $stackPtr, 'Missing');
+            $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'no');
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'yes');
+
+        // Check the PHP Version, which should be in some text before the first tag.
+        $found = false;
+        for ($i = ($commentStart + 1); $i < $commentEnd; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                break;
+            } else if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING
+                && strstr(strtolower($tokens[$i]['content']), 'php version') !== false
             ) {
-                // Found a class token right after comment doc block.
-                $newlineToken = $phpcsFile->findNext(
-                    T_WHITESPACE,
-                    ($commentEnd + 1),
-                    $commentNext,
-                    false,
-                    $phpcsFile->eolChar
-                );
-
-                if ($newlineToken !== false) {
-                    $newlineToken = $phpcsFile->findNext(
-                        T_WHITESPACE,
-                        ($newlineToken + 1),
-                        $commentNext,
-                        false,
-                        $phpcsFile->eolChar
-                    );
-
-                    if ($newlineToken === false) {
-                        // No blank line between the class token and the doc block.
-                        // The doc block is most likely a class comment.
-                        $error = 'Missing file doc comment';
-                        $phpcsFile->addError($error, $errorToken, 'Missing');
-                        return;
-                    }
-                }
-            }//end if
-
-            $comment = $phpcsFile->getTokensAsString(
-                $commentStart,
-                ($commentEnd - $commentStart + 1)
-            );
-
-            // Parse the header comment docblock.
-            try {
-                $this->commentParser = new PHP_CodeSniffer_CommentParser_ClassCommentParser($comment, $phpcsFile);
-                $this->commentParser->parse();
-            } catch (PHP_CodeSniffer_CommentParser_ParserException $e) {
-                $line = ($e->getLineWithinComment() + $commentStart);
-                $phpcsFile->addError($e->getMessage(), $line, 'FailedParse');
-                return;
+                $found = true;
+                break;
             }
+        }
 
-            $comment = $this->commentParser->getComment();
-            if (is_null($comment) === true) {
-                $error = 'File doc comment is empty';
-                $phpcsFile->addError($error, $commentStart, 'Empty');
-                return;
-            }
+        if ($found === false) {
+            $error = 'PHP version not specified';
+            $phpcsFile->addWarning($error, $commentEnd, 'MissingVersion');
+        }
 
-            // No extra newline before short description.
-            $short        = $comment->getShortComment();
-            $newlineCount = 0;
-            $newlineSpan  = strspn($short, $phpcsFile->eolChar);
-            if ($short !== '' && $newlineSpan > 0) {
-                $error = 'Extra newline(s) found before file comment short description';
-                $phpcsFile->addError($error, ($commentStart + 1), 'SpacingBefore');
-            }
+        // Check each tag.
+        $this->processTags($phpcsFile, $stackPtr, $commentStart);
 
-            $newlineCount = (substr_count($short, $phpcsFile->eolChar) + 1);
-
-            // Exactly one blank line between short and long description.
-            $long = $comment->getLongComment();
-            if (empty($long) === false) {
-                $between        = $comment->getWhiteSpaceBetween();
-                $newlineBetween = substr_count($between, $phpcsFile->eolChar);
-                if ($newlineBetween !== 2) {
-                    $error = 'There must be exactly one blank line between descriptions in file comment';
-                    $phpcsFile->addError($error, ($commentStart + $newlineCount + 1), 'DescriptionSpacing');
-                }
-
-                $newlineCount += $newlineBetween;
-            }
-
-            // Exactly one blank line before tags.
-            $tags = $this->commentParser->getTagOrders();
-            if (count($tags) > 1) {
-                $newlineSpan = $comment->getNewlineAfter();
-                if ($newlineSpan !== 2) {
-                    $error = 'There must be exactly one blank line before the tags in file comment';
-                    if ($long !== '') {
-                        $newlineCount += (substr_count($long, $phpcsFile->eolChar) - $newlineSpan + 1);
-                    }
-
-                    $phpcsFile->addError($error, ($commentStart + $newlineCount), 'SpacingBeforeTags');
-                    $short = rtrim($short, $phpcsFile->eolChar.' ');
-                }
-            }
-
-            // Check the PHP Version.
-            $this->processPHPVersion($commentStart, $commentEnd, $long);
-
-            // Check each tag.
-            $this->processTags($commentStart, $commentEnd);
-        }//end if
+        // Ignore the rest of the file.
+        return ($phpcsFile->numTokens + 1);
 
     }//end process()
 
 
     /**
-     * Check that the PHP version is specified.
-     *
-     * @param int    $commentStart Position in the stack where the comment started.
-     * @param int    $commentEnd   Position in the stack where the comment ended.
-     * @param string $commentText  The text of the function comment.
-     *
-     * @return void
-     */
-    protected function processPHPVersion($commentStart, $commentEnd, $commentText)
-    {
-        if (strstr(strtolower($commentText), 'php version') === false) {
-            $error = 'PHP version not specified';
-             $this->currentFile->addWarning($error, $commentEnd, 'MissingVersion');
-        }
-
-    }//end processPHPVersion()
-
-
-    /**
      * Processes each required or optional tag.
      *
-     * @param int $commentStart Position in the stack where the comment started.
-     * @param int $commentEnd   Position in the stack where the comment ended.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart Position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processTags($commentStart, $commentEnd)
+    protected function processTags($phpcsFile, $stackPtr, $commentStart)
     {
-        $docBlock    = (get_class($this) === 'CCHits_Sniffs_Commenting_FileCommentSniff') ? 'file' : 'class';
-        $foundTags   = $this->commentParser->getTagOrders();
-        $orderIndex  = 0;
-        $indentation = array();
-        $longestTag  = 0;
-        $errorPos    = 0;
+        $tokens = $phpcsFile->getTokens();
 
-        foreach ($this->tags as $tag => $info) {
+        if (get_class($this) === 'PHP_CodeSniffer\Standards\CCHits\Sniffs\Commenting\FileCommentSniff') {
+            $docBlock = 'file';
+        } else {
+            $docBlock = 'class';
+        }
 
-            // Required tag missing.
-            if ($info['required'] === true && in_array($tag, $foundTags) === false) {
-                $error = 'Missing @%s tag in %s comment';
-                $data  = array(
-                              $tag,
-                              $docBlock,
-                             );
-                $this->currentFile->addError($error, $commentEnd, 'MissingTag', $data);
+        $commentEnd = $tokens[$commentStart]['comment_closer'];
+
+        $foundTags = [];
+        $tagTokens = [];
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            $name = $tokens[$tag]['content'];
+            if (isset($this->tags[$name]) === false) {
                 continue;
             }
 
-             // Get the line number for current tag.
-            $tagName = ucfirst($tag);
-            if ($info['allow_multiple'] === true) {
-                $tagName .= 's';
+            if ($this->tags[$name]['allow_multiple'] === false && isset($tagTokens[$name]) === true) {
+                $error = 'Only one %s tag is allowed in a %s comment';
+                $data  = [
+                    $name,
+                    $docBlock,
+                ];
+                $phpcsFile->addError($error, $tag, 'Duplicate'.ucfirst(substr($name, 1)).'Tag', $data);
             }
 
-            $getMethod  = 'get'.$tagName;
-            $tagElement = $this->commentParser->$getMethod();
-            if (is_null($tagElement) === true || empty($tagElement) === true) {
+            $foundTags[]        = $name;
+            $tagTokens[$name][] = $tag;
+
+            $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+            if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
+                $error = 'Content missing for %s tag in %s comment';
+                $data  = [
+                    $name,
+                    $docBlock,
+                ];
+                $phpcsFile->addError($error, $tag, 'Empty'.ucfirst(substr($name, 1)).'Tag', $data);
                 continue;
-            }
-
-            $errorPos = $commentStart;
-            if (is_array($tagElement) === false) {
-                $errorPos = ($commentStart + $tagElement->getLine());
-            }
-
-            // Get the tag order.
-            $foundIndexes = array_keys($foundTags, $tag);
-
-            if (count($foundIndexes) > 1) {
-                // Multiple occurance not allowed.
-                if ($info['allow_multiple'] === false) {
-                    $error = 'Only 1 @%s tag is allowed in a %s comment';
-                    $data  = array(
-                              $tag,
-                              $docBlock,
-                             );
-                    $this->currentFile->addError($error, $errorPos, 'DuplicateTag', $data);
-                } else {
-                    // Make sure same tags are grouped together.
-                    $i     = 0;
-                    $count = $foundIndexes[0];
-                    foreach ($foundIndexes as $index) {
-                        if ($index !== $count) {
-                            $errorPosIndex
-                                = ($errorPos + $tagElement[$i]->getLine());
-                            $error = '@%s tags must be grouped together';
-                            $data  = array($tag);
-                            $this->currentFile->addError($error, $errorPosIndex, 'TagsNotGrouped', $data);
-                        }
-
-                        $i++;
-                        $count++;
-                    }
-                }
-            }//end if
-
-            // Check tag order.
-            if ($foundIndexes[0] > $orderIndex) {
-                $orderIndex = $foundIndexes[0];
-            } else {
-                if (is_array($tagElement) === true && empty($tagElement) === false) {
-                    $errorPos += $tagElement[0]->getLine();
-                }
-
-                $error = 'The @%s tag is in the wrong order; the tag %s';
-                $data  = array(
-                          $tag,
-                          $info['order_text'],
-                         );
-                $this->currentFile->addError($error, $errorPos, 'WrongTagOrder', $data);
-            }
-
-            // Store the indentation for checking.
-            $len = strlen($tag);
-            if ($len > $longestTag) {
-                $longestTag = $len;
-            }
-
-            if (is_array($tagElement) === true) {
-                foreach ($tagElement as $key => $element) {
-                    $indentation[] = array(
-                                      'tag'   => $tag,
-                                      'space' => $this->getIndentation($tag, $element),
-                                      'line'  => $element->getLine(),
-                                     );
-                }
-            } else {
-                $indentation[] = array(
-                                  'tag'   => $tag,
-                                  'space' => $this->getIndentation($tag, $tagElement),
-                                 );
-            }
-
-            $method = 'process'.$tagName;
-            if (method_exists($this, $method) === true) {
-                // Process each tag if a method is defined.
-                call_user_func(array($this, $method), $errorPos);
-            } else {
-                if (is_array($tagElement) === true) {
-                    foreach ($tagElement as $key => $element) {
-                        $element->process(
-                            $this->currentFile,
-                            $commentStart,
-                            $docBlock
-                        );
-                    }
-                } else {
-                     $tagElement->process(
-                         $this->currentFile,
-                         $commentStart,
-                         $docBlock
-                     );
-                }
             }
         }//end foreach
 
-        foreach ($indentation as $indentInfo) {
-            if ($indentInfo['space'] !== 0
-                && $indentInfo['space'] !== ($longestTag + 1)
-            ) {
-                $expected = (($longestTag - strlen($indentInfo['tag'])) + 1);
-                $space    = ($indentInfo['space'] - strlen($indentInfo['tag']));
-                $error    = '@%s tag comment indented incorrectly; expected %s spaces but found %s';
-                $data     = array(
-                             $indentInfo['tag'],
-                             $expected,
-                             $space,
-                            );
-
-                $getTagMethod = 'get'.ucfirst($indentInfo['tag']);
-
-                if ($this->tags[$indentInfo['tag']]['allow_multiple'] === true) {
-                    $line = $indentInfo['line'];
-                } else {
-                    $tagElem = $this->commentParser->$getTagMethod();
-                    $line    = $tagElem->getLine();
+        // Check if the tags are in the correct position.
+        $pos = 0;
+        foreach ($this->tags as $tag => $tagData) {
+            if (isset($tagTokens[$tag]) === false) {
+                if ($tagData['required'] === true) {
+                    $error = 'Missing %s tag in %s comment';
+                    $data  = [
+                        $tag,
+                        $docBlock,
+                    ];
+                    $phpcsFile->addError($error, $commentEnd, 'Missing'.ucfirst(substr($tag, 1)).'Tag', $data);
                 }
 
-                $this->currentFile->addError($error, ($commentStart + $line), 'TagIndent', $data);
+                continue;
+            } else {
+                $method = 'process'.substr($tag, 1);
+                if (method_exists($this, $method) === true) {
+                    // Process each tag if a method is defined.
+                    call_user_func([$this, $method], $phpcsFile, $tagTokens[$tag]);
+                }
             }
-        }
+
+            if (isset($foundTags[$pos]) === false) {
+                break;
+            }
+
+            if ($foundTags[$pos] !== $tag) {
+                $error = 'The tag in position %s should be the %s tag';
+                $data  = [
+                    ($pos + 1),
+                    $tag,
+                ];
+                $phpcsFile->addError($error, $tokens[$commentStart]['comment_tags'][$pos], ucfirst(substr($tag, 1)).'TagOrder', $data);
+            }
+
+            // Account for multiple tags.
+            $pos++;
+            while (isset($foundTags[$pos]) === true && $foundTags[$pos] === $tag) {
+                $pos++;
+            }
+        }//end foreach
 
     }//end processTags()
 
 
     /**
-     * Get the indentation information of each tag.
-     *
-     * @param string                                   $tagName    The name of the
-     *                                                             doc comment
-     *                                                             element.
-     * @param PHP_CodeSniffer_CommentParser_DocElement $tagElement The doc comment
-     *                                                             element.
-     *
-     * @return void
-     */
-    protected function getIndentation($tagName, $tagElement)
-    {
-        if ($tagElement instanceof PHP_CodeSniffer_CommentParser_SingleElement) {
-            if ($tagElement->getContent() !== '') {
-                return (strlen($tagName) + substr_count($tagElement->getWhitespaceBeforeContent(), ' '));
-            }
-        } else if ($tagElement instanceof PHP_CodeSniffer_CommentParser_PairElement) {
-            if ($tagElement->getValue() !== '') {
-                return (strlen($tagName) + substr_count($tagElement->getWhitespaceBeforeValue(), ' '));
-            }
-        }
-
-        return 0;
-
-    }//end getIndentation()
-
-
-    /**
      * Process the category tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processCategory($errorPos)
+    protected function processCategory($phpcsFile, array $tags)
     {
-        $category = $this->commentParser->getCategory();
-        if ($category !== null) {
-            $content = $category->getContent();
-            if ($content !== '') {
-                if (PHP_CodeSniffer::isUnderscoreName($content) !== true) {
-                    $newContent = str_replace(' ', '_', $content);
-                    $nameBits   = explode('_', $newContent);
-                    $firstBit   = array_shift($nameBits);
-                    $newName    = ucfirst($firstBit).'_';
-                    foreach ($nameBits as $bit) {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            if (Common::isUnderscoreName($content) !== true) {
+                $newContent = str_replace(' ', '_', $content);
+                $nameBits   = explode('_', $newContent);
+                $firstBit   = array_shift($nameBits);
+                $newName    = ucfirst($firstBit).'_';
+                foreach ($nameBits as $bit) {
+                    if ($bit !== '') {
                         $newName .= ucfirst($bit).'_';
                     }
-
-                    $error     = 'Category name "%s" is not valid; consider "%s" instead';
-                    $validName = trim($newName, '_');
-                    $data      = array(
-                                  $content,
-                                  $validName,
-                                 );
-                    $this->currentFile->addError($error, $errorPos, 'InvalidCategory', $data);
                 }
-            } else {
-                $error = '@category tag must contain a name';
-                $this->currentFile->addError($error, $errorPos, 'EmptyCategory');
+
+                $error     = 'Category name "%s" is not valid; consider "%s" instead';
+                $validName = trim($newName, '_');
+                $data      = [
+                    $content,
+                    $validName,
+                ];
+                $phpcsFile->addError($error, $tag, 'InvalidCategory', $data);
             }
-        }
+        }//end foreach
 
     }//end processCategory()
 
@@ -578,38 +340,52 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
     /**
      * Process the package tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processPackage($errorPos)
+    protected function processPackage($phpcsFile, array $tags)
     {
-        $package = $this->commentParser->getPackage();
-        if ($package !== null) {
-            $content = $package->getContent();
-            if ($content !== '') {
-                if (PHP_CodeSniffer::isUnderscoreName($content) !== true) {
-                    $newContent = str_replace(' ', '_', $content);
-                    $nameBits   = explode('_', $newContent);
-                    $firstBit   = array_shift($nameBits);
-                    $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
-                    foreach ($nameBits as $bit) {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            if (Common::isUnderscoreName($content) === true) {
+                continue;
+            }
+
+            $newContent = str_replace(' ', '_', $content);
+            $newContent = trim($newContent, '_');
+            $newContent = preg_replace('/[^A-Za-z_]/', '', $newContent);
+
+            if ($newContent === '') {
+                $error = 'Package name "%s" is not valid';
+                $data  = [$content];
+                $phpcsFile->addError($error, $tag, 'InvalidPackageValue', $data);
+            } else {
+                $nameBits = explode('_', $newContent);
+                $firstBit = array_shift($nameBits);
+                $newName  = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
+                foreach ($nameBits as $bit) {
+                    if ($bit !== '') {
                         $newName .= strtoupper($bit{0}).substr($bit, 1).'_';
                     }
-
-                    $error     = 'Package name "%s" is not valid; consider "%s" instead';
-                    $validName = trim($newName, '_');
-                    $data      = array(
-                                  $content,
-                                  $validName,
-                                 );
-                    $this->currentFile->addError($error, $errorPos, 'InvalidPackage', $data);
                 }
-            } else {
-                $error = '@package tag must contain a name';
-                $this->currentFile->addError($error, $errorPos, 'EmptyPackage');
-            }
-        }
+
+                $error     = 'Package name "%s" is not valid; consider "%s" instead';
+                $validName = trim($newName, '_');
+                $data      = [
+                    $content,
+                    $validName,
+                ];
+                $phpcsFile->addError($error, $tag, 'InvalidPackage', $data);
+            }//end if
+        }//end foreach
 
     }//end processPackage()
 
@@ -617,38 +393,43 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
     /**
      * Process the subpackage tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processSubpackage($errorPos)
+    protected function processSubpackage($phpcsFile, array $tags)
     {
-        $package = $this->commentParser->getSubpackage();
-        if ($package !== null) {
-            $content = $package->getContent();
-            if ($content !== '') {
-                if (PHP_CodeSniffer::isUnderscoreName($content) !== true) {
-                    $newContent = str_replace(' ', '_', $content);
-                    $nameBits   = explode('_', $newContent);
-                    $firstBit   = array_shift($nameBits);
-                    $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
-                    foreach ($nameBits as $bit) {
-                        $newName .= strtoupper($bit{0}).substr($bit, 1).'_';
-                    }
-
-                    $error     = 'Subpackage name "%s" is not valid; consider "%s" instead';
-                    $validName = trim($newName, '_');
-                    $data      = array(
-                                  $content,
-                                  $validName,
-                                 );
-                    $this->currentFile->addError($error, $errorPos, 'InvalidSubpackage', $data);
-                }
-            } else {
-                $error = '@subpackage tag must contain a name';
-                $this->currentFile->addError($error, $errorPos, 'EmptySubpackage');
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
             }
-        }
+
+            $content = $tokens[($tag + 2)]['content'];
+            if (Common::isUnderscoreName($content) === true) {
+                continue;
+            }
+
+            $newContent = str_replace(' ', '_', $content);
+            $nameBits   = explode('_', $newContent);
+            $firstBit   = array_shift($nameBits);
+            $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
+            foreach ($nameBits as $bit) {
+                if ($bit !== '') {
+                    $newName .= strtoupper($bit{0}).substr($bit, 1).'_';
+                }
+            }
+
+            $error     = 'Subpackage name "%s" is not valid; consider "%s" instead';
+            $validName = trim($newName, '_');
+            $data      = [
+                $content,
+                $validName,
+            ];
+            $phpcsFile->addError($error, $tag, 'InvalidSubpackage', $data);
+        }//end foreach
 
     }//end processSubpackage()
 
@@ -656,102 +437,97 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
     /**
      * Process the author tag(s) that this header comment has.
      *
-     * This function is different from other _process functions
-     * as $authors is an array of SingleElements, so we work out
-     * the errorPos for each element separately
-     *
-     * @param int $commentStart The position in the stack where
-     *                          the comment started.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processAuthors($commentStart)
+    protected function processAuthor($phpcsFile, array $tags)
     {
-         $authors = $this->commentParser->getAuthors();
-        // Report missing return.
-        if (empty($authors) === false) {
-            foreach ($authors as $author) {
-                $errorPos = ($commentStart + $author->getLine());
-                $content  = $author->getContent();
-                if ($content !== '') {
-                    $local = '\da-zA-Z-_+';
-                    // Dot character cannot be the first or last character
-                    // in the local-part.
-                    $localMiddle = $local.'.\w';
-                    if (preg_match('/^([^<]*)\s+<(['.$local.']['.$localMiddle.']*['.$local.']@[\da-zA-Z][-.\w]*[\da-zA-Z]\.[a-zA-Z]{2,7})>$/', $content) === 0) {
-                        $error = 'Content of the @author tag must be in the form "Display Name <username@example.com>"';
-                        $this->currentFile->addError($error, $errorPos, 'InvalidAuthors');
-                    }
-                } else {
-                    $error    = 'Content missing for @author tag in %s comment';
-                    $docBlock = (get_class($this) === 'CCHits_Sniffs_Commenting_FileCommentSniff') ? 'file' : 'class';
-                    $data     = array($docBlock);
-                    $this->currentFile->addError($error, $errorPos, 'EmptyAuthors', $data);
-                }
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            $local   = '\da-zA-Z-_+';
+            // Dot character cannot be the first or last character in the local-part.
+            $localMiddle = $local.'.\w';
+            if (preg_match('/^([^<]*)\s+<(['.$local.'](['.$localMiddle.']*['.$local.'])*@[\da-zA-Z][-.\w]*[\da-zA-Z]\.[a-zA-Z]{2,7})>$/', $content) === 0) {
+                $error = 'Content of the @author tag must be in the form "Display Name <username@example.com>"';
+                $phpcsFile->addError($error, $tag, 'InvalidAuthors');
             }
         }
 
-    }//end processAuthors()
+    }//end processAuthor()
 
 
     /**
      * Process the copyright tags.
      *
-     * @param int $commentStart The position in the stack where
-     *                          the comment started.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processCopyrights($commentStart)
+    protected function processCopyright($phpcsFile, array $tags)
     {
-        $copyrights = $this->commentParser->getCopyrights();
-        foreach ($copyrights as $copyright) {
-            $errorPos = ($commentStart + $copyright->getLine());
-            $content  = $copyright->getContent();
-            if ($content !== '') {
-                $matches = array();
-                if (preg_match('/^([0-9]{4})((.{1})([0-9]{4}))? (.+)$/', $content, $matches) !== 0) {
-                    // Check earliest-latest year order.
-                    if ($matches[3] !== '') {
-                        if ($matches[3] !== '-') {
-                            $error = 'A hyphen must be used between the earliest and latest year';
-                            $this->currentFile->addError($error, $errorPos, 'CopyrightHyphen');
-                        }
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
 
-                        if ($matches[4] !== '' && $matches[4] < $matches[1]) {
-                            $error = "Invalid year span \"$matches[1]$matches[3]$matches[4]\" found; consider \"$matches[4]-$matches[1]\" instead";
-                            $this->currentFile->addWarning($error, $errorPos, 'InvalidCopyright');
-                        }
+            $content = $tokens[($tag + 2)]['content'];
+            $matches = [];
+            if (preg_match('/^([0-9]{4})((.{1})([0-9]{4}))? (.+)$/', $content, $matches) !== 0) {
+                // Check earliest-latest year order.
+                if ($matches[3] !== '' && $matches[3] !== null) {
+                    if ($matches[3] !== '-') {
+                        $error = 'A hyphen must be used between the earliest and latest year';
+                        $phpcsFile->addError($error, $tag, 'CopyrightHyphen');
                     }
-                } else {
-                    $error = '@copyright tag must contain a year and the name of the copyright holder';
-                    $this->currentFile->addError($error, $errorPos, 'EmptyCopyright');
+
+                    if ($matches[4] !== '' && $matches[4] !== null && $matches[4] < $matches[1]) {
+                        $error = "Invalid year span \"$matches[1]$matches[3]$matches[4]\" found; consider \"$matches[4]-$matches[1]\" instead";
+                        $phpcsFile->addWarning($error, $tag, 'InvalidCopyright');
+                    }
                 }
             } else {
                 $error = '@copyright tag must contain a year and the name of the copyright holder';
-                $this->currentFile->addError($error, $errorPos, 'EmptyCopyright');
-            }//end if
-        }//end if
+                $phpcsFile->addError($error, $tag, 'IncompleteCopyright');
+            }
+        }//end foreach
 
-    }//end processCopyrights()
+    }//end processCopyright()
 
 
     /**
      * Process the license tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processLicense($errorPos)
+    protected function processLicense($phpcsFile, array $tags)
     {
-        $license = $this->commentParser->getLicense();
-        if ($license !== null) {
-            $value   = $license->getValue();
-            $comment = $license->getComment();
-            if ($value === '' || $comment === '') {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            $matches = [];
+            preg_match('/^([^\s]+)\s+(.*)/', $content, $matches);
+            if (count($matches) !== 3) {
                 $error = '@license tag must contain a URL and a license name';
-                $this->currentFile->addError($error, $errorPos, 'EmptyLicense');
+                $phpcsFile->addError($error, $tag, 'IncompleteLicense');
             }
         }
 
@@ -761,25 +537,29 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
     /**
      * Process the version tag.
      *
-     * @param int $errorPos The line number where the error occurs.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array                       $tags      The tokens for these tags.
      *
      * @return void
      */
-    protected function processVersion($errorPos)
+    protected function processVersion($phpcsFile, array $tags)
     {
-        $version = $this->commentParser->getVersion();
-        if ($version !== null) {
-            $content = $version->getContent();
-            $matches = array();
-            if (empty($content) === true) {
-                $error = 'Content missing for @version tag in file comment';
-                $this->currentFile->addError($error, $errorPos, 'EmptyVersion');
-            } else if (strstr($content, 'CVS:') === false
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+
+            $content = $tokens[($tag + 2)]['content'];
+            if (strstr($content, 'CVS:') === false
                 && strstr($content, 'SVN:') === false
+                && strstr($content, 'GIT:') === false
+                && strstr($content, 'HG:') === false
             ) {
-                $error = 'Invalid version "%s" in file comment; consider "CVS: <cvs_id>" or "SVN: <svn_id>" instead';
-                $data  = array($content);
-                $this->currentFile->addWarning($error, $errorPos, 'InvalidVersion', $data);
+                $error = 'Invalid version "%s" in file comment; consider "CVS: <cvs_id>" or "SVN: <svn_id>" or "GIT: <git_id>" or "HG: <hg_id>" instead';
+                $data  = [$content];
+                $phpcsFile->addWarning($error, $tag, 'InvalidVersion', $data);
             }
         }
 
@@ -787,5 +567,3 @@ class CCHits_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/.phpcs/CCHits/Sniffs/Commenting/FunctionCommentSniff.php
@@ -2,86 +2,19 @@
 /**
  * Parses and verifies the doc comments for functions.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: FunctionCommentSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_FunctionCommentParser', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_CommentParser_FunctionCommentParser not found');
-}
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Commenting;
 
-/**
- * Parses and verifies the doc comments for functions.
- *
- * Verifies that :
- * <ul>
- *  <li>A comment exists</li>
- *  <li>There is a blank newline after the short description.</li>
- *  <li>There is a blank newline between the long and short description.</li>
- *  <li>There is a blank newline between the long description and tags.</li>
- *  <li>Parameter names represent those in the method.</li>
- *  <li>Parameter comments are in the correct order</li>
- *  <li>Parameter comments are complete</li>
- *  <li>A space is present before the first and after the last parameter</li>
- *  <li>A return type exists</li>
- *  <li>There must be one blank line between body and headline comments.</li>
- *  <li>Any throw tag must have an exception class.</li>
- * </ul>
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sniff
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class FunctionCommentSniff implements Sniff
 {
-
-    /**
-     * The name of the method that we are currently processing.
-     *
-     * @var string
-     */
-    private $_methodName = '';
-
-    /**
-     * The position in the stack where the fucntion token was found.
-     *
-     * @var int
-     */
-    private $_functionToken = null;
-
-    /**
-     * The position in the stack where the class token was found.
-     *
-     * @var int
-     */
-    private $_classToken = null;
-
-    /**
-     * The function comment parser for the current method.
-     *
-     * @var PHP_CodeSniffer_Comment_Parser_FunctionCommentParser
-     */
-    protected $commentParser = null;
-
-    /**
-     * The current PHP_CodeSniffer_File object we are processing.
-     *
-     * @var PHP_CodeSniffer_File
-     */
-    protected $currentFile = null;
 
 
     /**
@@ -91,7 +24,7 @@ class CCHits_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_S
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return [T_FUNCTION];
 
     }//end register()
 
@@ -99,393 +32,426 @@ class CCHits_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_S
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
-        $find = array(
-                 T_COMMENT,
-                 T_DOC_COMMENT,
-                 T_CLASS,
-                 T_FUNCTION,
-                 T_OPEN_TAG,
-                );
+        $tokens = $phpcsFile->getTokens();
+        $find   = Tokens::$methodPrefixes;
+        $find[] = T_WHITESPACE;
 
-        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1));
-
-        if ($commentEnd === false) {
-            return;
+        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            // Inline comments might just be closing comments for
+            // control structures or functions instead of function comments
+            // using the wrong comment type. If there is other code on the line,
+            // assume they relate to that code.
+            $prev = $phpcsFile->findPrevious($find, ($commentEnd - 1), null, true);
+            if ($prev !== false && $tokens[$prev]['line'] === $tokens[$commentEnd]['line']) {
+                $commentEnd = $prev;
+            }
         }
 
-        $this->currentFile = $phpcsFile;
-        $tokens            = $phpcsFile->getTokens();
-
-        // If the token that we found was a class or a function, then this
-        // function has no doc comment.
-        $code = $tokens[$commentEnd]['code'];
-
-        if ($code === T_COMMENT) {
-            $error = 'You must use "/**" style comments for a function comment';
-            $phpcsFile->addError($error, $stackPtr, 'WrongStyle');
-            return;
-        } else if ($code !== T_DOC_COMMENT) {
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT
+        ) {
             $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
+            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'no');
+            return;
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'yes');
+        }
+
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $phpcsFile->addError('You must use "/**" style comments for a function comment', $stackPtr, 'WrongStyle');
             return;
         }
 
-        // If there is any code between the function keyword and the doc block
-        // then the doc block is not for us.
-        $ignore    = PHP_CodeSniffer_Tokens::$scopeModifiers;
-        $ignore[]  = T_STATIC;
-        $ignore[]  = T_WHITESPACE;
-        $ignore[]  = T_ABSTRACT;
-        $ignore[]  = T_FINAL;
-        $prevToken = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
-        if ($prevToken !== $commentEnd) {
-            $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
-            return;
+        if ($tokens[$commentEnd]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
+            $error = 'There must be no blank lines after the function comment';
+            $phpcsFile->addError($error, $commentEnd, 'SpacingAfter');
         }
 
-        $this->_functionToken = $stackPtr;
-
-        $this->_classToken = null;
-        foreach ($tokens[$stackPtr]['conditions'] as $condPtr => $condition) {
-            if ($condition === T_CLASS || $condition === T_INTERFACE) {
-                $this->_classToken = $condPtr;
-                break;
-            }
-        }
-
-        // If the first T_OPEN_TAG is right before the comment, it is probably
-        // a file comment.
-        $commentStart = ($phpcsFile->findPrevious(T_DOC_COMMENT, ($commentEnd - 1), null, true) + 1);
-        $prevToken    = $phpcsFile->findPrevious(T_WHITESPACE, ($commentStart - 1), null, true);
-        if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
-            // Is this the first open tag?
-            if ($stackPtr === 0 || $phpcsFile->findPrevious(T_OPEN_TAG, ($prevToken - 1)) === false) {
-                $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
-                return;
-            }
-        }
-
-        $comment           = $phpcsFile->getTokensAsString($commentStart, ($commentEnd - $commentStart + 1));
-        $this->_methodName = $phpcsFile->getDeclarationName($stackPtr);
-
-        try {
-            $this->commentParser = new PHP_CodeSniffer_CommentParser_FunctionCommentParser($comment, $phpcsFile);
-            $this->commentParser->parse();
-        } catch (PHP_CodeSniffer_CommentParser_ParserException $e) {
-            $line = ($e->getLineWithinComment() + $commentStart);
-            $phpcsFile->addError($e->getMessage(), $line, 'FailedParse');
-            return;
-        }
-
-        $comment = $this->commentParser->getComment();
-        if (is_null($comment) === true) {
-            $error = 'Function doc comment is empty';
-            $phpcsFile->addError($error, $commentStart, 'Empty');
-            return;
-        }
-
-        $this->processParams($commentStart);
-        $this->processReturn($commentStart, $commentEnd);
-        $this->processThrows($commentStart);
-
-        // No extra newline before short description.
-        $short        = $comment->getShortComment();
-        $newlineCount = 0;
-        $newlineSpan  = strspn($short, $phpcsFile->eolChar);
-        if ($short !== '' && $newlineSpan > 0) {
-            $error = 'Extra newline(s) found before function comment short description';
-            $phpcsFile->addError($error, ($commentStart + 1), 'SpacingBeforeShort');
-        }
-
-        $newlineCount = (substr_count($short, $phpcsFile->eolChar) + 1);
-
-        // Exactly one blank line between short and long description.
-        $long = $comment->getLongComment();
-        if (empty($long) === false) {
-            $between        = $comment->getWhiteSpaceBetween();
-            $newlineBetween = substr_count($between, $phpcsFile->eolChar);
-            if ($newlineBetween !== 2) {
-                $error = 'There must be exactly one blank line between descriptions in function comment';
-                $phpcsFile->addError($error, ($commentStart + $newlineCount + 1), 'SpacingAfterShort');
-            }
-
-            $newlineCount += $newlineBetween;
-        }
-
-        // Exactly one blank line before tags.
-        $params = $this->commentParser->getTagOrders();
-        if (count($params) > 1) {
-            $newlineSpan = $comment->getNewlineAfter();
-            if ($newlineSpan !== 2) {
-                $error = 'There must be exactly one blank line before the tags in function comment';
-                if ($long !== '') {
-                    $newlineCount += (substr_count($long, $phpcsFile->eolChar) - $newlineSpan + 1);
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] === '@see') {
+                // Make sure the tag isn't empty.
+                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
+                    $error = 'Content missing for @see tag in function comment';
+                    $phpcsFile->addError($error, $tag, 'EmptySees');
                 }
-
-                $phpcsFile->addError($error, ($commentStart + $newlineCount), 'SpacingBeforeTags');
-                $short = rtrim($short, $phpcsFile->eolChar.' ');
             }
         }
+
+        $this->processReturn($phpcsFile, $stackPtr, $commentStart);
+        $this->processThrows($phpcsFile, $stackPtr, $commentStart);
+        $this->processParams($phpcsFile, $stackPtr, $commentStart);
 
     }//end process()
 
 
     /**
-     * Process any throw tags that this function comment has.
+     * Process the return comment of this function comment.
      *
-     * @param int $commentStart The position in the stack where the
-     *                          comment started.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processThrows($commentStart)
+    protected function processReturn(File $phpcsFile, $stackPtr, $commentStart)
     {
-        if (count($this->commentParser->getThrows()) === 0) {
+        $tokens = $phpcsFile->getTokens();
+
+        // Skip constructor and destructor.
+        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
+        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
+
+        $return = null;
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] === '@return') {
+                if ($return !== null) {
+                    $error = 'Only 1 @return tag is allowed in a function comment';
+                    $phpcsFile->addError($error, $tag, 'DuplicateReturn');
+                    return;
+                }
+
+                $return = $tag;
+            }
+        }
+
+        if ($isSpecialMethod === true) {
             return;
         }
 
-        foreach ($this->commentParser->getThrows() as $throw) {
-
-            $exception = $throw->getValue();
-            $errorPos  = ($commentStart + $throw->getLine());
-
-            if ($exception === '') {
-                $error = '@throws tag must contain the exception class name';
-                $this->currentFile->addError($error, $errorPos, 'EmptyThrows');
+        if ($return !== null) {
+            $content = $tokens[($return + 2)]['content'];
+            if (empty($content) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                $error = 'Return type missing for @return tag in function comment';
+                $phpcsFile->addError($error, $return, 'MissingReturnType');
             }
-        }
-
-    }//end processThrows()
-
-
-    /**
-     * Process the return comment of this function comment.
-     *
-     * @param int $commentStart The position in the stack where the comment started.
-     * @param int $commentEnd   The position in the stack where the comment ended.
-     *
-     * @return void
-     */
-    protected function processReturn($commentStart, $commentEnd)
-    {
-        // Skip constructor and destructor.
-        $className = '';
-        if ($this->_classToken !== null) {
-            $className = $this->currentFile->getDeclarationName($this->_classToken);
-            $className = strtolower(ltrim($className, '_'));
-        }
-
-        $methodName      = strtolower(ltrim($this->_methodName, '_'));
-        $isSpecialMethod = ($this->_methodName === '__construct' || $this->_methodName === '__destruct');
-
-        if ($isSpecialMethod === false && $methodName !== $className) {
-            // Report missing return tag.
-            if ($this->commentParser->getReturn() === null) {
-                $error = 'Missing @return tag in function comment';
-                $this->currentFile->addError($error, $commentEnd, 'MissingReturn');
-            } else if (trim($this->commentParser->getReturn()->getRawContent()) === '') {
-                $error    = '@return tag is empty in function comment';
-                $errorPos = ($commentStart + $this->commentParser->getReturn()->getLine());
-                $this->currentFile->addError($error, $errorPos, 'EmptyReturn');
-            }
-        }
+        } else {
+            $error = 'Missing @return tag in function comment';
+            $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
+        }//end if
 
     }//end processReturn()
 
 
     /**
-     * Process the function parameter comments.
+     * Process any throw tags that this function comment has.
      *
-     * @param int $commentStart The position in the stack where
-     *                          the comment started.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processParams($commentStart)
+    protected function processThrows(File $phpcsFile, $stackPtr, $commentStart)
     {
-        $realParams = $this->currentFile->getMethodParameters($this->_functionToken);
+        $tokens = $phpcsFile->getTokens();
 
-        $params      = $this->commentParser->getParams();
-        $foundParams = array();
-
-        if (empty($params) === false) {
-
-            $lastParm = (count($params) - 1);
-            if (substr_count($params[$lastParm]->getWhitespaceAfter(), $this->currentFile->eolChar) !== 2) {
-                $error    = 'Last parameter comment requires a blank newline after it';
-                $errorPos = ($params[$lastParm]->getLine() + $commentStart);
-                $this->currentFile->addError($error, $errorPos, 'SpacingAfterParams');
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] !== '@throws') {
+                continue;
             }
 
-            // Parameters must appear immediately after the comment.
-            if ($params[0]->getOrder() !== 2) {
-                $error    = 'Parameters must appear immediately after the comment';
-                $errorPos = ($params[0]->getLine() + $commentStart);
-                $this->currentFile->addError($error, $errorPos, 'SpacingBeforeParams');
+            $exception = null;
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $matches = [];
+                preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($tag + 2)]['content'], $matches);
+                $exception = $matches[1];
             }
 
-            $previousParam      = null;
-            $spaceBeforeVar     = 10000;
-            $spaceBeforeComment = 10000;
-            $longestType        = 0;
-            $longestVar         = 0;
+            if ($exception === null) {
+                $error = 'Exception type missing for @throws tag in function comment';
+                $phpcsFile->addError($error, $tag, 'InvalidThrows');
+            }
+        }//end foreach
 
-            foreach ($params as $param) {
+    }//end processThrows()
 
-                $paramComment = trim($param->getComment());
-                $errorPos     = ($param->getLine() + $commentStart);
 
-                // Make sure that there is only one space before the var type.
-                if ($param->getWhitespaceBeforeType() !== ' ') {
-                    $error = 'Expected 1 space before variable type';
-                    $this->currentFile->addError($error, $errorPos, 'SpacingBeforeParamType');
+    /**
+     * Process the function parameter comments.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processParams(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $params  = [];
+        $maxType = 0;
+        $maxVar  = 0;
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] !== '@param') {
+                continue;
+            }
+
+            $type          = '';
+            $typeSpace     = 0;
+            $var           = '';
+            $varSpace      = 0;
+            $comment       = '';
+            $commentEnd    = 0;
+            $commentTokens = [];
+
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $matches = [];
+                preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+
+                if (empty($matches) === false) {
+                    $typeLen   = strlen($matches[1]);
+                    $type      = trim($matches[1]);
+                    $typeSpace = ($typeLen - strlen($type));
+                    $typeLen   = strlen($type);
+                    if ($typeLen > $maxType) {
+                        $maxType = $typeLen;
+                    }
                 }
 
-                $spaceCount = substr_count($param->getWhitespaceBeforeVarName(), ' ');
-                if ($spaceCount < $spaceBeforeVar) {
-                    $spaceBeforeVar = $spaceCount;
-                    $longestType    = $errorPos;
-                }
-
-                $spaceCount = substr_count($param->getWhitespaceBeforeComment(), ' ');
-
-                if ($spaceCount < $spaceBeforeComment && $paramComment !== '') {
-                    $spaceBeforeComment = $spaceCount;
-                    $longestVar         = $errorPos;
-                }
-
-                // Make sure they are in the correct order,
-                // and have the correct name.
-                $pos = $param->getPosition();
-
-                $paramName = ($param->getVarName() !== '') ? $param->getVarName() : '[ UNKNOWN ]';
-
-                if ($previousParam !== null) {
-                    $previousName = ($previousParam->getVarName() !== '') ? $previousParam->getVarName() : 'UNKNOWN';
-
-                    // Check to see if the parameters align properly.
-                    if ($param->alignsVariableWith($previousParam) === false) {
-                        $error = 'The variable names for parameters %s (%s) and %s (%s) do not align';
-                        $data  = array(
-                                  $previousName,
-                                  ($pos - 1),
-                                  $paramName,
-                                  $pos,
-                                 );
-                        $this->currentFile->addError($error, $errorPos, 'ParameterNamesNotAligned', $data);
+                if (isset($matches[2]) === true) {
+                    $var    = $matches[2];
+                    $varLen = strlen($var);
+                    if ($varLen > $maxVar) {
+                        $maxVar = $varLen;
                     }
 
-                    if ($param->alignsCommentWith($previousParam) === false) {
-                        $error = 'The comments for parameters %s (%s) and %s (%s) do not align';
-                        $data  = array(
-                                  $previousName,
-                                  ($pos - 1),
-                                  $paramName,
-                                  $pos,
-                                 );
-                        $this->currentFile->addError($error, $errorPos, 'ParameterCommentsNotAligned', $data);
-                    }
-                }//end if
+                    if (isset($matches[4]) === true) {
+                        $varSpace = strlen($matches[3]);
+                        $comment  = $matches[4];
 
-                // Make sure the names of the parameter comment matches the
-                // actual parameter.
-                if (isset($realParams[($pos - 1)]) === true) {
-                    $realName      = $realParams[($pos - 1)]['name'];
-                    $foundParams[] = $realName;
-
-                    // Append ampersand to name if passing by reference.
-                    if ($realParams[($pos - 1)]['pass_by_reference'] === true) {
-                        $realName = '&'.$realName;
-                    }
-
-                    if ($realName !== $paramName) {
-                        $code = 'ParamNameNoMatch';
-                        $data = array(
-                                    $paramName,
-                                    $realName,
-                                    $pos,
-                                );
-
-                        $error  = 'Doc comment for var %s does not match ';
-                        if (strtolower($paramName) === strtolower($realName)) {
-                            $error .= 'case of ';
-                            $code   = 'ParamNameNoCaseMatch';
+                        // Any strings until the next tag belong to this comment.
+                        if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                            $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+                        } else {
+                            $end = $tokens[$commentStart]['comment_closer'];
                         }
 
-                        $error .= 'actual variable name %s at position %s';
-
-                        $this->currentFile->addError($error, $errorPos, $code, $data);
-                    }
+                        for ($i = ($tag + 3); $i < $end; $i++) {
+                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                                $comment        .= ' '.$tokens[$i]['content'];
+                                $commentEnd      = $i;
+                                $commentTokens[] = $i;
+                            }
+                        }
+                    } else {
+                        $error = 'Missing parameter comment';
+                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
+                    }//end if
                 } else {
-                    // We must have an extra parameter comment.
-                    $error = 'Superfluous doc comment at position '.$pos;
-                    $this->currentFile->addError($error, $errorPos, 'ExtraParamComment');
-                }
+                    $error = 'Missing parameter name';
+                    $phpcsFile->addError($error, $tag, 'MissingParamName');
+                }//end if
+            } else {
+                $error = 'Missing parameter type';
+                $phpcsFile->addError($error, $tag, 'MissingParamType');
+            }//end if
 
-                if ($param->getVarName() === '') {
-                    $error = 'Missing parameter name at position '.$pos;
-                     $this->currentFile->addError($error, $errorPos, 'MissingParamName');
-                }
+            $params[] = [
+                'tag'            => $tag,
+                'type'           => $type,
+                'var'            => $var,
+                'comment'        => $comment,
+                'comment_end'    => $commentEnd,
+                'comment_tokens' => $commentTokens,
+                'type_space'     => $typeSpace,
+                'var_space'      => $varSpace,
+            ];
+        }//end foreach
 
-                if ($param->getType() === '') {
-                    $error = 'Missing type at position '.$pos;
-                    $this->currentFile->addError($error, $errorPos, 'MissingParamType');
-                }
+        $realParams  = $phpcsFile->getMethodParameters($stackPtr);
+        $foundParams = [];
 
-                if ($paramComment === '') {
-                    $error = 'Missing comment for param "%s" at position %s';
-                    $data  = array(
-                              $paramName,
-                              $pos,
-                             );
-                    $this->currentFile->addError($error, $errorPos, 'MissingParamComment', $data);
-                }
+        // We want to use ... for all variable length arguments, so add
+        // this prefix to the variable name so comparisons are easier.
+        foreach ($realParams as $pos => $param) {
+            if ($param['variable_length'] === true) {
+                $realParams[$pos]['name'] = '...'.$realParams[$pos]['name'];
+            }
+        }
 
-                $previousParam = $param;
-
-            }//end foreach
-
-            if ($spaceBeforeVar !== 1 && $spaceBeforeVar !== 10000 && $spaceBeforeComment !== 10000) {
-                $error = 'Expected 1 space after the longest type';
-                $this->currentFile->addError($error, $longestType, 'SpacingAfterLongType');
+        foreach ($params as $pos => $param) {
+            if ($param['var'] === '') {
+                continue;
             }
 
-            if ($spaceBeforeComment !== 1 && $spaceBeforeComment !== 10000) {
-                $error = 'Expected 1 space after the longest variable name';
-                $this->currentFile->addError($error, $longestVar, 'SpacingAfterLongName');
+            $foundParams[] = $param['var'];
+
+            // Check number of spaces after the type.
+            $spaces = ($maxType - strlen($param['type']) + 1);
+            if ($param['type_space'] !== $spaces) {
+                $error = 'Expected %s spaces after parameter type; %s found';
+                $data  = [
+                    $spaces,
+                    $param['type_space'],
+                ];
+
+                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamType', $data);
+                if ($fix === true) {
+                    $commentToken = ($param['tag'] + 2);
+
+                    $content  = $param['type'];
+                    $content .= str_repeat(' ', $spaces);
+                    $content .= $param['var'];
+                    $content .= str_repeat(' ', $param['var_space']);
+
+                    $wrapLength = ($tokens[$commentToken]['length'] - $param['type_space'] - $param['var_space'] - strlen($param['type']) - strlen($param['var']));
+
+                    $star        = $phpcsFile->findPrevious(T_DOC_COMMENT_STAR, $param['tag']);
+                    $spaceLength = (strlen($content) + $tokens[($commentToken - 1)]['length'] + $tokens[($commentToken - 2)]['length']);
+
+                    $padding  = str_repeat(' ', ($tokens[$star]['column'] - 1));
+                    $padding .= '* ';
+                    $padding .= str_repeat(' ', $spaceLength);
+
+                    $content .= wordwrap(
+                        $param['comment'],
+                        $wrapLength,
+                        $phpcsFile->eolChar.$padding
+                    );
+
+                    $phpcsFile->fixer->replaceToken($commentToken, $content);
+                    for ($i = ($commentToken + 1); $i <= $param['comment_end']; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                }//end if
+            }//end if
+
+            // Make sure the param name is correct.
+            if (isset($realParams[$pos]) === true) {
+                $realName = $realParams[$pos]['name'];
+                if ($realName !== $param['var']) {
+                    $code = 'ParamNameNoMatch';
+                    $data = [
+                        $param['var'],
+                        $realName,
+                    ];
+
+                    $error = 'Doc comment for parameter %s does not match ';
+                    if (strtolower($param['var']) === strtolower($realName)) {
+                        $error .= 'case of ';
+                        $code   = 'ParamNameNoCaseMatch';
+                    }
+
+                    $error .= 'actual variable name %s';
+
+                    $phpcsFile->addError($error, $param['tag'], $code, $data);
+                }
+            } else if (substr($param['var'], -4) !== ',...') {
+                // We must have an extra parameter comment.
+                $error = 'Superfluous parameter comment';
+                $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
+            }//end if
+
+            if ($param['comment'] === '') {
+                continue;
             }
 
-        }//end if
+            // Check number of spaces after the param name.
+            $spaces = ($maxVar - strlen($param['var']) + 1);
+            if ($param['var_space'] !== $spaces) {
+                $error = 'Expected %s spaces after parameter name; %s found';
+                $data  = [
+                    $spaces,
+                    $param['var_space'],
+                ];
 
-        $realNames = array();
+                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamName', $data);
+                if ($fix === true) {
+                    $commentToken = ($param['tag'] + 2);
+
+                    $content  = $param['type'];
+                    $content .= str_repeat(' ', $param['type_space']);
+                    $content .= $param['var'];
+                    $content .= str_repeat(' ', $spaces);
+
+                    $wrapLength = ($tokens[$commentToken]['length'] - $param['type_space'] - $param['var_space'] - strlen($param['type']) - strlen($param['var']));
+
+                    $star        = $phpcsFile->findPrevious(T_DOC_COMMENT_STAR, $param['tag']);
+                    $spaceLength = (strlen($content) + $tokens[($commentToken - 1)]['length'] + $tokens[($commentToken - 2)]['length']);
+
+                    $padding  = str_repeat(' ', ($tokens[$star]['column'] - 1));
+                    $padding .= '* ';
+                    $padding .= str_repeat(' ', $spaceLength);
+
+                    $content .= wordwrap(
+                        $param['comment'],
+                        $wrapLength,
+                        $phpcsFile->eolChar.$padding
+                    );
+
+                    $phpcsFile->fixer->replaceToken($commentToken, $content);
+                    for ($i = ($commentToken + 1); $i <= $param['comment_end']; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                }//end if
+            }//end if
+
+            // Check the alignment of multi-line param comments.
+            if ($param['tag'] !== $param['comment_end']) {
+                $wrapLength = ($tokens[($param['tag'] + 2)]['length'] - $param['type_space'] - $param['var_space'] - strlen($param['type']) - strlen($param['var']));
+
+                $startColumn = ($tokens[($param['tag'] + 2)]['column'] + $tokens[($param['tag'] + 2)]['length'] - $wrapLength);
+
+                $star     = $phpcsFile->findPrevious(T_DOC_COMMENT_STAR, $param['tag']);
+                $expected = ($startColumn - $tokens[$star]['column'] - 1);
+
+                foreach ($param['comment_tokens'] as $commentToken) {
+                    if ($tokens[$commentToken]['column'] === $startColumn) {
+                        continue;
+                    }
+
+                    $found = 0;
+                    if ($tokens[($commentToken - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                        $found = $tokens[($commentToken - 1)]['length'];
+                    }
+
+                    $error = 'Parameter comment not aligned correctly; expected %s spaces but found %s';
+                    $data  = [
+                        $expected,
+                        $found,
+                    ];
+                    $fix   = $phpcsFile->addFixableError($error, $commentToken, 'ParamCommentAlignment', $data);
+                    if ($fix === true) {
+                        $padding = str_repeat(' ', $expected);
+                        if ($tokens[($commentToken - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                            $phpcsFile->fixer->replaceToken(($commentToken - 1), $padding);
+                        } else {
+                            $phpcsFile->fixer->addContentBefore($commentToken, $padding);
+                        }
+                    }
+                }//end foreach
+            }//end if
+        }//end foreach
+
+        $realNames = [];
         foreach ($realParams as $realParam) {
             $realNames[] = $realParam['name'];
         }
 
-        // Report and missing comments.
+        // Report missing comments.
         $diff = array_diff($realNames, $foundParams);
         foreach ($diff as $neededParam) {
-            if (count($params) !== 0) {
-                $errorPos = ($params[(count($params) - 1)]->getLine() + $commentStart);
-            } else {
-                $errorPos = $commentStart;
-            }
-
-            $error = 'Doc comment for "%s" missing';
-            $data  = array($neededParam);
-            $this->currentFile->addError($error, $errorPos, 'MissingParamTag', $data);
+            $error = 'Doc comment for parameter "%s" missing';
+            $data  = [$neededParam];
+            $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
         }
 
     }//end processParams()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Commenting/InlineCommentSniff.php
+++ b/.phpcs/CCHits/Sniffs/Commenting/InlineCommentSniff.php
@@ -1,34 +1,18 @@
 <?php
 /**
- * PHP_CodeSniffer_Sniffs_CCHits_Commenting_InlineCommentSniff.
+ * Checks that no Perl-style comments are used.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: InlineCommentSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * PHP_CodeSniffer_Sniffs_CCHits_Commenting_InlineCommentSniff.
- *
- * Checks that no perl-style comments are used.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Sniff
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class InlineCommentSniff implements Sniff
 {
 
 
@@ -39,7 +23,7 @@ class CCHits_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Sni
      */
     public function register()
     {
-        return array(T_COMMENT);
+        return [T_COMMENT];
 
     }//end register()
 
@@ -47,25 +31,38 @@ class CCHits_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Sni
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['content']{0} === '#') {
+            $phpcsFile->recordMetric($stackPtr, 'Inline comment style', '# ...');
+
             $error  = 'Perl-style comments are not allowed. Use "// Comment."';
             $error .= ' or "/* comment */" instead.';
-            $phpcsFile->addError($error, $stackPtr, 'WrongStyle');
+            $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
+            if ($fix === true) {
+                $newComment = ltrim($tokens[$stackPtr]['content'], '# ');
+                $newComment = '// '.$newComment;
+                $phpcsFile->fixer->replaceToken($stackPtr, $newComment);
+            }
+        } else if ($tokens[$stackPtr]['content']{0} === '/'
+            && $tokens[$stackPtr]['content']{1} === '/'
+        ) {
+            $phpcsFile->recordMetric($stackPtr, 'Inline comment style', '// ...');
+        } else if ($tokens[$stackPtr]['content']{0} === '/'
+            && $tokens[$stackPtr]['content']{1} === '*'
+        ) {
+            $phpcsFile->recordMetric($stackPtr, 'Inline comment style', '/* ... */');
         }
 
     }//end process()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/.phpcs/CCHits/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -2,70 +2,46 @@
 /**
  * Verifies that control statements conform to their coding standards.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ControlSignatureSniff.php 244676 2007-10-23 06:05:14Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractPatternSniff not found');
-}
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\ControlStructures;
 
-/**
- * Verifies that control statements conform to their coding standards.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSniffer_Standards_AbstractPatternSniff
+use PHP_CodeSniffer\Sniffs\AbstractPatternSniff;
+
+class ControlSignatureSniff extends AbstractPatternSniff
 {
 
-
     /**
-     * Constructs a CCHits_Sniffs_ControlStructures_ControlSignatureSniff.
+     * If true, comments will be ignored if they are found in the code.
+     *
+     * @var boolean
      */
-    public function __construct()
-    {
-        parent::__construct(true);
-
-    }//end __construct()
+    public $ignoreComments = true;
 
 
     /**
      * Returns the patterns that this test wishes to verify.
      *
-     * @return array(string)
+     * @return string[]
      */
     protected function getPatterns()
     {
-        return array(
-                'do {EOL...} while (...);EOL',
-                'while (...) {EOL',
-                'for (...) {EOL',
-                'if (...) {EOL',
-                'foreach (...) {EOL',
-                '} else if (...) {EOL',
-                '} elseif (...) {EOL',
-                '} else {EOL',
-                'do {EOL',
-               );
+        return [
+            'do {EOL...} while (...);EOL',
+            'while (...) {EOL',
+            'for (...) {EOL',
+            'if (...) {EOL',
+            'foreach (...) {EOL',
+            '} else if (...) {EOL',
+            '} elseif (...) {EOL',
+            '} else {EOL',
+            'do {EOL',
+        ];
 
     }//end getPatterns()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/.phpcs/CCHits/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -1,33 +1,37 @@
 <?php
 /**
- * CCHits_Sniffs_ControlStructures_MultiLineConditionSniff.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: MultiLineConditionSniff.php 308347 2011-02-15 04:42:58Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-/**
- * CCHits_Sniffs_ControlStructures_MultiLineConditionSniff.
- *
  * Ensure multi-line IF conditions are defined correctly.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_CodeSniffer_Sniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class MultiLineConditionSniff implements Sniff
 {
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 4;
 
 
     /**
@@ -37,7 +41,10 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
      */
     public function register()
     {
-        return array(T_IF);
+        return [
+            T_IF,
+            T_ELSEIF,
+        ];
 
     }//end register()
 
@@ -45,15 +52,42 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+            return;
+        }
+
+        $openBracket    = $tokens[$stackPtr]['parenthesis_opener'];
+        $closeBracket   = $tokens[$stackPtr]['parenthesis_closer'];
+        $spaceAfterOpen = 0;
+        if ($tokens[($openBracket + 1)]['code'] === T_WHITESPACE) {
+            if (strpos($tokens[($openBracket + 1)]['content'], $phpcsFile->eolChar) !== false) {
+                $spaceAfterOpen = 'newline';
+            } else {
+                $spaceAfterOpen = strlen($tokens[($openBracket + 1)]['content']);
+            }
+        }
+
+        if ($spaceAfterOpen !== 0) {
+            $error = 'First condition of a multi-line IF statement must directly follow the opening parenthesis';
+            $fix   = $phpcsFile->addFixableError($error, ($openBracket + 1), 'SpacingAfterOpenBrace');
+            if ($fix === true) {
+                if ($spaceAfterOpen === 'newline') {
+                    $phpcsFile->fixer->replaceToken(($openBracket + 1), '');
+                } else {
+                    $phpcsFile->fixer->replaceToken(($openBracket + 1), '');
+                }
+            }
+        }
 
         // We need to work out how far indented the if statement
         // itself is, so we can work out how far to indent conditions.
@@ -72,25 +106,47 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
         // Each line between the parenthesis should be indented 4 spaces
         // and start with an operator, unless the line is inside a
         // function call, in which case it is ignored.
-        $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
-        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
-        $lastLine     = $tokens[$openBracket]['line'];
-        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
-            if ($tokens[$i]['line'] !== $lastLine) {
+        $prevLine = $tokens[$openBracket]['line'];
+        for ($i = ($openBracket + 1); $i <= $closeBracket; $i++) {
+            if ($i === $closeBracket && $tokens[$openBracket]['line'] !== $tokens[$i]['line']) {
+                $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($i - 1), null, true);
+                if ($tokens[$prev]['line'] === $tokens[$i]['line']) {
+                    // Closing bracket is on the same line as a condition.
+                    $error = 'Closing parenthesis of a multi-line IF statement must be on a new line';
+                    $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'CloseBracketNewLine');
+                    if ($fix === true) {
+                        // Account for a comment at the end of the line.
+                        $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
+                        if ($tokens[$next]['code'] !== T_COMMENT) {
+                            $phpcsFile->fixer->addNewlineBefore($closeBracket);
+                        } else {
+                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                            $phpcsFile->fixer->beginChangeset();
+                            $phpcsFile->fixer->replaceToken($closeBracket, '');
+                            $phpcsFile->fixer->addContentBefore($next, ')');
+                            $phpcsFile->fixer->endChangeset();
+                        }
+                    }
+                }
+            }//end if
+
+            if ($tokens[$i]['line'] !== $prevLine) {
                 if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
                     $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
                     if ($next !== $closeBracket) {
-                        // Closing bracket is on the same line as a condition.
-                        $error = 'Closing parenthesis of a multi-line IF statement must be on a new line';
-                        $phpcsFile->addError($error, $i, 'CloseBracketNewLine');
-                        $expectedIndent = ($statementIndent + 4);
+                        $expectedIndent = ($statementIndent + $this->indent);
                     } else {
                         // Closing brace needs to be indented to the same level
-                        // as the function.
+                        // as the statement.
                         $expectedIndent = $statementIndent;
-                    }
+                    }//end if
                 } else {
-                    $expectedIndent = ($statementIndent + 4);
+                    $expectedIndent = ($statementIndent + $this->indent);
+                }//end if
+
+                if ($tokens[$i]['code'] === T_COMMENT) {
+                    $prevLine = $tokens[$i]['line'];
+                    continue;
                 }
 
                 // We changed lines, so this should be a whitespace indent token.
@@ -102,22 +158,44 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
 
                 if ($expectedIndent !== $foundIndent) {
                     $error = 'Multi-line IF statement not indented correctly; expected %s spaces but found %s';
-                    $data  = array(
-                              $expectedIndent,
-                              $foundIndent,
-                             );
-                    $phpcsFile->addError($error, $i, 'Alignment', $data);
-                }
+                    $data  = [
+                        $expectedIndent,
+                        $foundIndent,
+                    ];
 
-                if ($tokens[$i]['line'] !== $tokens[$closeBracket]['line']) {
-                    $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
-                    if (in_array($tokens[$next]['code'], PHP_CodeSniffer_Tokens::$booleanOperators) === false) {
-                        $error = 'Each line in a multi-line IF statement must begin with a boolean operator';
-                        $phpcsFile->addError($error, $i, 'StartWithBoolean');
+                    $fix = $phpcsFile->addFixableError($error, $i, 'Alignment', $data);
+                    if ($fix === true) {
+                        $spaces = str_repeat(' ', $expectedIndent);
+                        if ($foundIndent === 0) {
+                            $phpcsFile->fixer->addContentBefore($i, $spaces);
+                        } else {
+                            $phpcsFile->fixer->replaceToken($i, $spaces);
+                        }
                     }
                 }
 
-                $lastLine = $tokens[$i]['line'];
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, $i, null, true);
+                if ($next !== $closeBracket) {
+                    if (isset(Tokens::$booleanOperators[$tokens[$next]['code']]) === false) {
+                        $error = 'Each line in a multi-line IF statement must begin with a boolean operator';
+                        $fix   = $phpcsFile->addFixableError($error, $i, 'StartWithBoolean');
+                        if ($fix === true) {
+                            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $openBracket, true);
+                            if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true) {
+                                $phpcsFile->fixer->beginChangeset();
+                                $phpcsFile->fixer->replaceToken($prev, '');
+                                $phpcsFile->fixer->addContentBefore($next, $tokens[$prev]['content'].' ');
+                                $phpcsFile->fixer->endChangeset();
+                            } else {
+                                for ($x = ($prev + 1); $x < $next; $x++) {
+                                    $phpcsFile->fixer->replaceToken($x, '');
+                                }
+                            }
+                        }
+                    }
+                }//end if
+
+                $prevLine = $tokens[$i]['line'];
             }//end if
 
             if ($tokens[$i]['code'] === T_STRING) {
@@ -126,7 +204,7 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
                     // This is a function call, so skip to the end as they
                     // have their own indentation rules.
                     $i        = $tokens[$next]['parenthesis_closer'];
-                    $lastLine = $tokens[$i]['line'];
+                    $prevLine = $tokens[$i]['line'];
                     continue;
                 }
             }
@@ -139,39 +217,51 @@ class CCHits_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
         }
 
         // The opening brace needs to be one space away from the closing parenthesis.
-        if ($tokens[($closeBracket + 1)]['code'] !== T_WHITESPACE) {
-            $length = 0;
-        } else if ($tokens[($closeBracket + 1)]['content'] === $phpcsFile->eolChar) {
+        $openBrace = $tokens[$stackPtr]['scope_opener'];
+        $next      = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), $openBrace, true);
+        if ($next !== false) {
+            // Probably comments in between tokens, so don't check.
+            return;
+        }
+
+        if ($tokens[$openBrace]['line'] > $tokens[$closeBracket]['line']) {
             $length = -1;
-        } else {
+        } else if ($openBrace === ($closeBracket + 1)) {
+            $length = 0;
+        } else if ($openBrace === ($closeBracket + 2)
+            && $tokens[($closeBracket + 1)]['code'] === T_WHITESPACE
+        ) {
             $length = strlen($tokens[($closeBracket + 1)]['content']);
+        } else {
+            // Confused, so don't check.
+            $length = 1;
         }
 
-        if ($length !== 1) {
-            $data = array($length);
-            $code = 'SpaceBeforeOpenBrace';
+        if ($length === 1) {
+            return;
+        }
 
-            $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line IF statement; found ';
-            if ($length === -1) {
-                $error .= 'newline';
-                $code   = 'NewlineBeforeOpenBrace';
+        $data = [$length];
+        $code = 'SpaceBeforeOpenBrace';
+
+        $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line IF statement; found ';
+        if ($length === -1) {
+            $error .= 'newline';
+            $code   = 'NewlineBeforeOpenBrace';
+        } else {
+            $error .= '%s spaces';
+        }
+
+        $fix = $phpcsFile->addFixableError($error, ($closeBracket + 1), $code, $data);
+        if ($fix === true) {
+            if ($length === 0) {
+                $phpcsFile->fixer->addContent($closeBracket, ' ');
             } else {
-                $error .= '%s spaces';
+                $phpcsFile->fixer->replaceToken(($closeBracket + 1), ' ');
             }
-
-            $phpcsFile->addError($error, ($closeBracket + 1), $code, $data);
-        }
-
-        // And just in case they do something funny before the brace...
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
-        if ($next !== false && $tokens[$next]['code'] !== T_OPEN_CURLY_BRACKET) {
-            $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line IF statement';
-            $phpcsFile->addError($error, $next, 'NoSpaceBeforeOpenBrace');
         }
 
     }//end process()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Files/IncludingFileSniff.php
+++ b/.phpcs/CCHits/Sniffs/Files/IncludingFileSniff.php
@@ -1,49 +1,22 @@
 <?php
 /**
- * CCHits_Sniffs_Files_IncludingFileSniff.
+ * Ensure include_once is used in conditional situations and require_once is used elsewhere.
  *
- * PHP version 5
+ * Also checks that brackets do not surround the file being included.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: IncludingFileSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * CCHits_Sniffs_Files_IncludingFileSniff.
- *
- * Checks that the include_once is used in conditional situations, and
- * require_once is used elsewhere. Also checks that brackets do not surround
- * the file being included.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Files;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class IncludingFileSniff implements Sniff
 {
-
-    /**
-     * Conditions that should use include_once
-     *
-     * @var array(int)
-     */
-    private static $_conditions = array(
-                                   T_IF,
-                                   T_ELSE,
-                                   T_ELSEIF,
-                                   T_SWITCH,
-                                  );
 
 
     /**
@@ -53,12 +26,12 @@ class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
      */
     public function register()
     {
-        return array(
-                T_INCLUDE_ONCE,
-                T_REQUIRE_ONCE,
-                T_REQUIRE,
-                T_INCLUDE,
-               );
+        return [
+            T_INCLUDE_ONCE,
+            T_REQUIRE_ONCE,
+            T_REQUIRE,
+            T_INCLUDE,
+        ];
 
     }//end register()
 
@@ -66,24 +39,39 @@ class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS) {
             $error = '"%s" is a statement not a function; no parentheses are required';
-            $data  = array($tokens[$stackPtr]['content']);
-            $phpcsFile->addError($error, $stackPtr, 'BracketsNotRequired', $data);
+            $data  = [$tokens[$stackPtr]['content']];
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'BracketsNotRequired', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($tokens[$nextToken]['parenthesis_closer'], '');
+                if ($tokens[($nextToken - 1)]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($nextToken, ' ');
+                } else {
+                    $phpcsFile->fixer->replaceToken($nextToken, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
         }
 
-        $inCondition = (count($tokens[$stackPtr]['conditions']) !== 0) ? true : false;
+        if (count($tokens[$stackPtr]['conditions']) !== 0) {
+            $inCondition = true;
+        } else {
+            $inCondition = false;
+        }
 
         // Check to see if this including statement is within the parenthesis
         // of a condition. If that's the case then we need to process it as being
@@ -99,8 +87,8 @@ class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
         // Check to see if they are assigning the return value of this
         // including call. If they are then they are probably checking it, so
         // it's conditional.
-        $previous = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$previous]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens) === true) {
+        $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if (isset(Tokens::$assignmentTokens[$tokens[$previous]['code']]) === true) {
             // The have assigned the return value to it, so its conditional.
             $inCondition = true;
         }
@@ -111,22 +99,34 @@ class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
             if ($tokenCode === T_REQUIRE_ONCE) {
                 $error  = 'File is being conditionally included; ';
                 $error .= 'use "include_once" instead';
-                $phpcsFile->addError($error, $stackPtr, 'UseIncludeOnce');
+                $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'UseIncludeOnce');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, 'include_once');
+                }
             } else if ($tokenCode === T_REQUIRE) {
                 $error  = 'File is being conditionally included; ';
                 $error .= 'use "include" instead';
-                $phpcsFile->addError($error, $stackPtr, 'UseInclude');
+                $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'UseInclude');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, 'include');
+                }
             }
         } else {
             // We are unconditionally including, we need a require_once.
             if ($tokenCode === T_INCLUDE_ONCE) {
                 $error  = 'File is being unconditionally included; ';
                 $error .= 'use "require_once" instead';
-                $phpcsFile->addError($error, $stackPtr, 'UseRequireOnce');
+                $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'UseRequireOnce');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, 'require_once');
+                }
             } else if ($tokenCode === T_INCLUDE) {
                 $error  = 'File is being unconditionally included; ';
                 $error .= 'use "require" instead';
-                $phpcsFile->addError($error, $stackPtr, 'UseRequire');
+                $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'UseRequire');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, 'require');
+                }
             }
         }//end if
 
@@ -134,5 +134,3 @@ class CCHits_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/.phpcs/CCHits/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -1,33 +1,26 @@
 <?php
 /**
- * CCHits_Sniffs_Functions_FunctionDeclarationSniff.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: MultiLineAssignmentSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-/**
- * CCHits_Sniffs_Formatting_MultiLineAssignmentSniff.
- *
  * If an assignment goes over two lines, ensure the equal sign is indented.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSniffer_Sniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class MultiLineAssignmentSniff implements Sniff
 {
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 4;
 
 
     /**
@@ -37,7 +30,7 @@ class CCHits_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSniff
      */
     public function register()
     {
-        return array(T_EQUAL);
+        return [T_EQUAL];
 
     }//end register()
 
@@ -45,13 +38,13 @@ class CCHits_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -96,19 +89,18 @@ class CCHits_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSniff
         // Find the actual indent.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1));
 
-        $expectedIndent = ($assignmentIndent + 4);
+        $expectedIndent = ($assignmentIndent + $this->indent);
         $foundIndent    = strlen($tokens[$prev]['content']);
         if ($foundIndent !== $expectedIndent) {
             $error = 'Multi-line assignment not indented correctly; expected %s spaces but found %s';
-            $data  = array(
-                      $expectedIndent,
-                      $foundIndent,
-                     );
+            $data  = [
+                $expectedIndent,
+                $foundIndent,
+            ];
             $phpcsFile->addError($error, $stackPtr, 'Indent', $data);
         }
 
     }//end process()
 
-}//end class
 
-?>
+}//end class

--- a/.phpcs/CCHits/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/.phpcs/CCHits/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -1,33 +1,58 @@
 <?php
 /**
- * CCHits_Sniffs_Functions_FunctionCallSignatureSniff.
+ * Ensures function calls are formatted correctly.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: FunctionCallSignatureSniff.php 307869 2011-01-31 03:56:50Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * CCHits_Sniffs_Functions_FunctionCallSignatureSniff.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSniffer_Sniff
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class FunctionCallSignatureSniff implements Sniff
 {
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 4;
+
+    /**
+     * If TRUE, multiple arguments can be defined per line in a multi-line call.
+     *
+     * @var boolean
+     */
+    public $allowMultipleArguments = true;
+
+    /**
+     * How many spaces should follow the opening bracket.
+     *
+     * @var integer
+     */
+    public $requiredSpacesAfterOpen = 0;
+
+    /**
+     * How many spaces should precede the closing bracket.
+     *
+     * @var integer
+     */
+    public $requiredSpacesBeforeClose = 0;
 
 
     /**
@@ -37,7 +62,13 @@ class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSnif
      */
     public function register()
     {
-        return array(T_STRING);
+        $tokens = Tokens::$functionNameTokens;
+
+        $tokens[] = T_VARIABLE;
+        $tokens[] = T_CLOSE_CURLY_BRACKET;
+        $tokens[] = T_CLOSE_PARENTHESIS;
+
+        return $tokens;
 
     }//end register()
 
@@ -45,18 +76,27 @@ class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSnif
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
+        $this->requiredSpacesAfterOpen   = (int) $this->requiredSpacesAfterOpen;
+        $this->requiredSpacesBeforeClose = (int) $this->requiredSpacesBeforeClose;
         $tokens = $phpcsFile->getTokens();
 
+        if ($tokens[$stackPtr]['code'] === T_CLOSE_CURLY_BRACKET
+            && isset($tokens[$stackPtr]['scope_condition']) === true
+        ) {
+            // Not a function call.
+            return;
+        }
+
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -69,7 +109,7 @@ class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSnif
         }
 
         // Find the previous non-empty token.
-        $search   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $search   = Tokens::$emptyTokens;
         $search[] = T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === T_FUNCTION) {
@@ -82,64 +122,200 @@ class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSnif
         if (($stackPtr + 1) !== $openBracket) {
             // Checking this: $value = my_function[*](...).
             $error = 'Space before opening parenthesis of function call prohibited';
-            $phpcsFile->addError($error, $stackPtr, 'SpaceBeforeOpenBracket');
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceBeforeOpenBracket');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($stackPtr + 1); $i < $openBracket; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                // Modify the bracket as well to ensure a conflict if the bracket
+                // has been changed in some way by another sniff.
+                $phpcsFile->fixer->replaceToken($openBracket, '(');
+                $phpcsFile->fixer->endChangeset();
+            }
         }
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
         if ($tokens[$next]['code'] === T_SEMICOLON) {
-            if (in_array($tokens[($closeBracket + 1)]['code'], PHP_CodeSniffer_Tokens::$emptyTokens) === true) {
+            if (isset(Tokens::$emptyTokens[$tokens[($closeBracket + 1)]['code']]) === true) {
                 $error = 'Space after closing parenthesis of function call prohibited';
-                $phpcsFile->addError($error, $closeBracket, 'SpaceAfterCloseBracket');
+                $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'SpaceAfterCloseBracket');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($closeBracket + 1); $i < $next; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    // Modify the bracket as well to ensure a conflict if the bracket
+                    // has been changed in some way by another sniff.
+                    $phpcsFile->fixer->replaceToken($closeBracket, ')');
+                    $phpcsFile->fixer->endChangeset();
+                }
             }
         }
 
         // Check if this is a single line or multi-line function call.
-        if ($tokens[$openBracket]['line'] === $tokens[$closeBracket]['line']) {
-            $this->processSingleLineCall($phpcsFile, $stackPtr, $openBracket, $tokens);
-        } else {
+        if ($this->isMultiLineCall($phpcsFile, $stackPtr, $openBracket, $tokens) === true) {
             $this->processMultiLineCall($phpcsFile, $stackPtr, $openBracket, $tokens);
+        } else {
+            $this->processSingleLineCall($phpcsFile, $stackPtr, $openBracket, $tokens);
         }
 
     }//end process()
 
 
     /**
-     * Processes single-line calls.
+     * Determine if this is a multi-line function call.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-     * @param int                  $stackPtr    The position of the current token
-     *                                          in the stack passed in $tokens.
-     * @param int                  $openBracket The position of the openning bracket
-     *                                          in the stack passed in $tokens.
-     * @param array                $tokens      The stack of tokens that make up
-     *                                          the file.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the current token
+     *                                                 in the stack passed in $tokens.
+     * @param int                         $openBracket The position of the opening bracket
+     *                                                 in the stack passed in $tokens.
+     * @param array                       $tokens      The stack of tokens that make up
+     *                                                 the file.
      *
      * @return void
      */
-    public function processSingleLineCall(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $openBracket, $tokens)
+    public function isMultiLineCall(File $phpcsFile, $stackPtr, $openBracket, $tokens)
     {
-        if ($tokens[($openBracket + 1)]['code'] === T_WHITESPACE) {
+        $closeBracket = $tokens[$openBracket]['parenthesis_closer'];
+        if ($tokens[$openBracket]['line'] !== $tokens[$closeBracket]['line']) {
+            return true;
+        }
+
+        return false;
+
+    }//end isMultiLineCall()
+
+
+    /**
+     * Processes single-line calls.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the current token
+     *                                                 in the stack passed in $tokens.
+     * @param int                         $openBracket The position of the opening bracket
+     *                                                 in the stack passed in $tokens.
+     * @param array                       $tokens      The stack of tokens that make up
+     *                                                 the file.
+     *
+     * @return void
+     */
+    public function processSingleLineCall(File $phpcsFile, $stackPtr, $openBracket, $tokens)
+    {
+        // If the function call has no arguments or comments, enforce 0 spaces.
+        $closer = $tokens[$openBracket]['parenthesis_closer'];
+        if ($openBracket === ($closer - 1)) {
+            return;
+        }
+
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($openBracket + 1), $closer, true);
+        if ($next === false) {
+            $requiredSpacesAfterOpen   = 0;
+            $requiredSpacesBeforeClose = 0;
+        } else {
+            $requiredSpacesAfterOpen   = $this->requiredSpacesAfterOpen;
+            $requiredSpacesBeforeClose = $this->requiredSpacesBeforeClose;
+        }
+
+        if ($requiredSpacesAfterOpen === 0 && $tokens[($openBracket + 1)]['code'] === T_WHITESPACE) {
             // Checking this: $value = my_function([*]...).
             $error = 'Space after opening parenthesis of function call prohibited';
-            $phpcsFile->addError($error, $stackPtr, 'SpaceAfterOpenBracket');
-        }
-
-        $closer = $tokens[$openBracket]['parenthesis_closer'];
-
-        if ($tokens[($closer - 1)]['code'] === T_WHITESPACE) {
-            // Checking this: $value = my_function(...[*]).
-            $between = $phpcsFile->findNext(T_WHITESPACE, ($openBracket + 1), null, true);
-
-            // Only throw an error if there is some content between the parenthesis.
-            // i.e., Checking for this: $value = my_function().
-            // If there is no content, then we would have thrown an error in the
-            // previous IF statement because it would look like this:
-            // $value = my_function( ).
-            if ($between !== $closer) {
-                $error = 'Space before closing parenthesis of function call prohibited';
-                $phpcsFile->addError($error, $closer, 'SpaceBeforeCloseBracket');
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterOpenBracket');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($openBracket + 1), '');
             }
+        } else if ($requiredSpacesAfterOpen > 0) {
+            $spaceAfterOpen = 0;
+            if ($tokens[($openBracket + 1)]['code'] === T_WHITESPACE) {
+                $spaceAfterOpen = strlen($tokens[($openBracket + 1)]['content']);
+            }
+
+            if ($spaceAfterOpen !== $requiredSpacesAfterOpen) {
+                $error = 'Expected %s spaces after opening bracket; %s found';
+                $data  = [
+                    $requiredSpacesAfterOpen,
+                    $spaceAfterOpen,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterOpenBracket', $data);
+                if ($fix === true) {
+                    $padding = str_repeat(' ', $requiredSpacesAfterOpen);
+                    if ($spaceAfterOpen === 0) {
+                        $phpcsFile->fixer->addContent($openBracket, $padding);
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($openBracket + 1), $padding);
+                    }
+                }
+            }
+        }//end if
+
+        // Checking this: $value = my_function(...[*]).
+        $spaceBeforeClose = 0;
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($closer - 1), $openBracket, true);
+        if ($tokens[$prev]['code'] === T_END_HEREDOC || $tokens[$prev]['code'] === T_END_NOWDOC) {
+            // Need a newline after these tokens, so ignore this rule.
+            return;
         }
+
+        if ($tokens[$prev]['line'] !== $tokens[$closer]['line']) {
+            $spaceBeforeClose = 'newline';
+        } else if ($tokens[($closer - 1)]['code'] === T_WHITESPACE) {
+            $spaceBeforeClose = strlen($tokens[($closer - 1)]['content']);
+        }
+
+        if ($spaceBeforeClose !== $requiredSpacesBeforeClose) {
+            $error = 'Expected %s spaces before closing bracket; %s found';
+            $data  = [
+                $requiredSpacesBeforeClose,
+                $spaceBeforeClose,
+            ];
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceBeforeCloseBracket', $data);
+            if ($fix === true) {
+                $padding = str_repeat(' ', $requiredSpacesBeforeClose);
+
+                if ($spaceBeforeClose === 0) {
+                    $phpcsFile->fixer->addContentBefore($closer, $padding);
+                } else if ($spaceBeforeClose === 'newline') {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    $closingContent = ')';
+
+                    $next = $phpcsFile->findNext(T_WHITESPACE, ($closer + 1), null, true);
+                    if ($tokens[$next]['code'] === T_SEMICOLON) {
+                        $closingContent .= ';';
+                        for ($i = ($closer + 1); $i <= $next; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+                    }
+
+                    // We want to jump over any whitespace or inline comment and
+                    // move the closing parenthesis after any other token.
+                    $prev = ($closer - 1);
+                    while (isset(Tokens::$emptyTokens[$tokens[$prev]['code']]) === true) {
+                        if (($tokens[$prev]['code'] === T_COMMENT)
+                            && (strpos($tokens[$prev]['content'], '*/') !== false)
+                        ) {
+                            break;
+                        }
+
+                        $prev--;
+                    }
+
+                    $phpcsFile->fixer->addContent($prev, $padding.$closingContent);
+
+                    $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closer - 1), null, true);
+                    for ($i = ($prevNonWhitespace + 1); $i <= $closer; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                } else {
+                    $phpcsFile->fixer->replaceToken(($closer - 1), $padding);
+                }//end if
+            }//end if
+        }//end if
 
     }//end processSingleLineCall()
 
@@ -147,105 +323,264 @@ class CCHits_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSnif
     /**
      * Processes multi-line calls.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-     * @param int                  $stackPtr    The position of the current token
-     *                                          in the stack passed in $tokens.
-     * @param int                  $openBracket The position of the openning bracket
-     *                                          in the stack passed in $tokens.
-     * @param array                $tokens      The stack of tokens that make up
-     *                                          the file.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the current token
+     *                                                 in the stack passed in $tokens.
+     * @param int                         $openBracket The position of the opening bracket
+     *                                                 in the stack passed in $tokens.
+     * @param array                       $tokens      The stack of tokens that make up
+     *                                                 the file.
      *
      * @return void
      */
-    public function processMultiLineCall(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $openBracket, $tokens)
+    public function processMultiLineCall(File $phpcsFile, $stackPtr, $openBracket, $tokens)
     {
         // We need to work out how far indented the function
         // call itself is, so we can work out how far to
         // indent the arguments.
-        $functionIndent = 0;
-        for ($i = ($stackPtr - 1); $i >= 0; $i--) {
-            if ($tokens[$i]['line'] !== $tokens[$stackPtr]['line']) {
-                $i++;
-                break;
+        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);
+        if ($tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
+            && $tokens[($first - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
+        ) {
+            // We are in a multi-line string, so find the start and use
+            // the indent from there.
+            $prev  = $phpcsFile->findPrevious(T_CONSTANT_ENCAPSED_STRING, ($first - 2), null, true);
+            $first = $phpcsFile->findFirstOnLine(Tokens::$emptyTokens, $prev, true);
+        }
+
+        $foundFunctionIndent = 0;
+        if ($first !== false) {
+            if ($tokens[$first]['code'] === T_INLINE_HTML) {
+                $trimmed = ltrim($tokens[$first]['content']);
+                if ($trimmed === '') {
+                    $foundFunctionIndent = strlen($tokens[$first]['content']);
+                } else {
+                    $foundFunctionIndent = (strlen($tokens[$first]['content']) - strlen($trimmed));
+                }
+            } else {
+                $foundFunctionIndent = ($tokens[$first]['column'] - 1);
             }
         }
 
-        if ($tokens[$i]['code'] === T_WHITESPACE) {
-            $functionIndent = strlen($tokens[$i]['content']);
+        // Make sure the function indent is divisible by the indent size.
+        // We round down here because this accounts for times when the
+        // surrounding code is indented a little too far in, and not correctly
+        // at a tab stop. Without this, the function will be indented a further
+        // $indent spaces to the right.
+        $functionIndent = (int) (floor($foundFunctionIndent / $this->indent) * $this->indent);
+        $adjustment     = 0;
+
+        if ($foundFunctionIndent !== $functionIndent) {
+            $error = 'Opening statement of multi-line function call not indented correctly; expected %s spaces but found %s';
+            $data  = [
+                $functionIndent,
+                $foundFunctionIndent,
+            ];
+
+            $fix = $phpcsFile->addFixableError($error, $first, 'OpeningIndent', $data);
+            if ($fix === true) {
+                $adjustment = ($functionIndent - $foundFunctionIndent);
+                $padding    = str_repeat(' ', $functionIndent);
+                if ($foundFunctionIndent === 0) {
+                    $phpcsFile->fixer->addContentBefore($first, $padding);
+                } else {
+                    $phpcsFile->fixer->replaceToken(($first - 1), $padding);
+                }
+            }
         }
 
-        // Each line between the parenthesis should be indented 4 spaces.
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
+            $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ContentAfterOpenBracket');
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent(
+                    $openBracket,
+                    $phpcsFile->eolChar.str_repeat(' ', ($foundFunctionIndent + $this->indent))
+                );
+            }
+        }
+
         $closeBracket = $tokens[$openBracket]['parenthesis_closer'];
-        $lastLine     = $tokens[$openBracket]['line'];
-        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
-            // Skip nested function calls.
-            if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
-                $i        = $tokens[$i]['parenthesis_closer'];
-                $lastLine = $tokens[$i]['line'];
-                continue;
+        $prev         = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBracket - 1), null, true);
+        if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
+            $error = 'Closing parenthesis of a multi-line function call must be on a line by itself';
+            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'CloseBracketLine');
+            if ($fix === true) {
+                $phpcsFile->fixer->addContentBefore(
+                    $closeBracket,
+                    $phpcsFile->eolChar.str_repeat(' ', ($foundFunctionIndent + $this->indent))
+                );
+            }
+        }
+
+        // Each line between the parenthesis should be indented n spaces.
+        $lastLine = ($tokens[$openBracket]['line'] - 1);
+        $argStart = null;
+        $argEnd   = null;
+
+        // Start processing at the first argument.
+        $i = $phpcsFile->findNext(T_WHITESPACE, ($openBracket + 1), null, true);
+        if ($tokens[($i - 1)]['code'] === T_WHITESPACE
+            && $tokens[($i - 1)]['line'] === $tokens[$i]['line']
+        ) {
+            // Make sure we check the indent.
+            $i--;
+        }
+
+        for ($i; $i < $closeBracket; $i++) {
+            if ($i > $argStart && $i < $argEnd) {
+                $inArg = true;
+            } else {
+                $inArg = false;
             }
 
             if ($tokens[$i]['line'] !== $lastLine) {
                 $lastLine = $tokens[$i]['line'];
 
-                // We changed lines, so this should be a whitespace indent token.
-                if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$heredocTokens) === true) {
-                    // Ignore heredoc indentation.
+                // Ignore heredoc indentation.
+                if (isset(Tokens::$heredocTokens[$tokens[$i]['code']]) === true) {
                     continue;
                 }
 
-                if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$stringTokens) === true) {
-                    if ($tokens[$i]['code'] === $tokens[($i - 1)]['code']) {
-                        // Ignore multi-line string indentation.
-                        continue;
+                // Ignore multi-line string indentation.
+                if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === true
+                    && $tokens[$i]['code'] === $tokens[($i - 1)]['code']
+                ) {
+                    continue;
+                }
+
+                // Ignore inline HTML.
+                if ($tokens[$i]['code'] === T_INLINE_HTML) {
+                    continue;
+                }
+
+                if ($tokens[$i]['line'] !== $tokens[$openBracket]['line']) {
+                    // We changed lines, so this should be a whitespace indent token, but first make
+                    // sure it isn't a blank line because we don't need to check indent unless there
+                    // is actually some code to indent.
+                    if ($tokens[$i]['code'] === T_WHITESPACE) {
+                        $nextCode = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), ($closeBracket + 1), true);
+                        if ($tokens[$nextCode]['line'] !== $lastLine) {
+                            if ($inArg === false) {
+                                $error = 'Empty lines are not allowed in multi-line function calls';
+                                $fix   = $phpcsFile->addFixableError($error, $i, 'EmptyLine');
+                                if ($fix === true) {
+                                    $phpcsFile->fixer->replaceToken($i, '');
+                                }
+                            }
+
+                            continue;
+                        }
+                    } else {
+                        $nextCode = $i;
                     }
-                }
 
-                if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
-                    // Closing brace needs to be indented to the same level
-                    // as the function call.
-                    $expectedIndent = $functionIndent;
+                    if ($tokens[$nextCode]['line'] === $tokens[$closeBracket]['line']) {
+                        // Closing brace needs to be indented to the same level
+                        // as the function call.
+                        $inArg          = false;
+                        $expectedIndent = ($foundFunctionIndent + $adjustment);
+                    } else {
+                        $expectedIndent = ($foundFunctionIndent + $this->indent + $adjustment);
+                    }
+
+                    if ($tokens[$i]['code'] !== T_WHITESPACE
+                        && $tokens[$i]['code'] !== T_DOC_COMMENT_WHITESPACE
+                    ) {
+                        // Just check if it is a multi-line block comment. If so, we can
+                        // calculate the indent from the whitespace before the content.
+                        if ($tokens[$i]['code'] === T_COMMENT
+                            && $tokens[($i - 1)]['code'] === T_COMMENT
+                        ) {
+                            $trimmedLength = strlen(ltrim($tokens[$i]['content']));
+                            if ($trimmedLength === 0) {
+                                // This is a blank comment line, so indenting it is
+                                // pointless.
+                                continue;
+                            }
+
+                            $foundIndent = (strlen($tokens[$i]['content']) - $trimmedLength);
+                        } else {
+                            $foundIndent = 0;
+                        }
+                    } else {
+                        $foundIndent = strlen($tokens[$i]['content']);
+                    }
+
+                    if ($foundIndent < $expectedIndent
+                        || ($inArg === false
+                        && $expectedIndent !== $foundIndent)
+                    ) {
+                        $error = 'Multi-line function call not indented correctly; expected %s spaces but found %s';
+                        $data  = [
+                            $expectedIndent,
+                            $foundIndent,
+                        ];
+
+                        $fix = $phpcsFile->addFixableError($error, $i, 'Indent', $data);
+                        if ($fix === true) {
+                            $padding = str_repeat(' ', $expectedIndent);
+                            if ($foundIndent === 0) {
+                                $phpcsFile->fixer->addContentBefore($i, $padding);
+                            } else {
+                                if ($tokens[$i]['code'] === T_COMMENT) {
+                                    $comment = $padding.ltrim($tokens[$i]['content']);
+                                    $phpcsFile->fixer->replaceToken($i, $comment);
+                                } else {
+                                    $phpcsFile->fixer->replaceToken($i, $padding);
+                                }
+                            }
+                        }
+                    }//end if
                 } else {
-                    $expectedIndent = ($functionIndent + 4);
-                }
+                    $nextCode = $i;
+                }//end if
 
-                if ($tokens[$i]['code'] !== T_WHITESPACE) {
-                    $foundIndent = 0;
-                } else {
-                    $foundIndent = strlen($tokens[$i]['content']);
-                }
-
-                if ($expectedIndent !== $foundIndent) {
-                    $error = 'Multi-line function call not indented correctly; expected %s spaces but found %s';
-                    $data  = array(
-                              $expectedIndent,
-                              $foundIndent,
-                             );
-                    $phpcsFile->addError($error, $i, 'Indent', $data);
+                if ($inArg === false) {
+                    $argStart = $nextCode;
+                    $argEnd   = $phpcsFile->findEndOfStatement($nextCode);
                 }
             }//end if
 
-            // Skip the rest of a closure.
-            if ($tokens[$i]['code'] === T_CLOSURE) {
-                $i        = $tokens[$i]['scope_closer'];
-                $lastLine = $tokens[$i]['line'];
-                continue;
-            }
+            // If we are within an argument we should be ignoring commas
+            // as these are not signaling the end of an argument.
+            if ($inArg === false && $tokens[$i]['code'] === T_COMMA) {
+                $next = $phpcsFile->findNext([T_WHITESPACE, T_COMMENT], ($i + 1), $closeBracket, true);
+                if ($next === false) {
+                    continue;
+                }
+
+                if ($this->allowMultipleArguments === false) {
+                    // Comma has to be the last token on the line.
+                    if ($tokens[$i]['line'] === $tokens[$next]['line']) {
+                        $error = 'Only one argument is allowed per line in a multi-line function call';
+                        $fix   = $phpcsFile->addFixableError($error, $next, 'MultipleArguments');
+                        if ($fix === true) {
+                            $phpcsFile->fixer->beginChangeset();
+                            for ($x = ($next - 1); $x > $i; $x--) {
+                                if ($tokens[$x]['code'] !== T_WHITESPACE) {
+                                    break;
+                                }
+
+                                $phpcsFile->fixer->replaceToken($x, '');
+                            }
+
+                            $phpcsFile->fixer->addContentBefore(
+                                $next,
+                                $phpcsFile->eolChar.str_repeat(' ', ($foundFunctionIndent + $this->indent))
+                            );
+                            $phpcsFile->fixer->endChangeset();
+                        }
+                    }
+                }//end if
+
+                $argStart = $next;
+                $argEnd   = $phpcsFile->findEndOfStatement($next);
+            }//end if
         }//end for
-
-        if ($tokens[($openBracket + 1)]['content'] !== $phpcsFile->eolChar) {
-            $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
-            $phpcsFile->addError($error, $stackPtr, 'ContentAfterOpenBracket');
-        }
-
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBracket - 1), null, true);
-        if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
-            $error = 'Closing parenthesis of a multi-line function call must be on a line by itself';
-            $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
-        }
 
     }//end processMultiLineCall()
 
 
 }//end class
-?>

--- a/.phpcs/CCHits/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/.phpcs/CCHits/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -1,33 +1,39 @@
 <?php
 /**
- * CCHits_Sniffs_Functions_FunctionDeclarationSniff.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: FunctionDeclarationSniff.php 308840 2011-03-02 05:32:18Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-/**
- * CCHits_Sniffs_Functions_FunctionDeclarationSniff.
- *
  * Ensure single and multi-line function declarations are defined correctly.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffer_Sniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceKernighanRitchieSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceBsdAllmanSniff;
+
+class FunctionDeclarationSniff implements Sniff
 {
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 4;
 
 
     /**
@@ -37,7 +43,10 @@ class CCHits_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffe
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
 
     }//end register()
 
@@ -45,26 +54,171 @@ class CCHits_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffe
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Check if this is a single line or multi-line declaration.
+        if (isset($tokens[$stackPtr]['parenthesis_opener']) === false
+            || isset($tokens[$stackPtr]['parenthesis_closer']) === false
+            || $tokens[$stackPtr]['parenthesis_opener'] === null
+            || $tokens[$stackPtr]['parenthesis_closer'] === null
+        ) {
+            return;
+        }
+
         $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
         $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
-        if ($tokens[$openBracket]['line'] === $tokens[$closeBracket]['line']) {
-            $this->processSingleLineDeclaration($phpcsFile, $stackPtr, $tokens);
-        } else {
+
+        if (strtolower($tokens[$stackPtr]['content']) === 'function') {
+            // Must be one space after the FUNCTION keyword.
+            if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
+                $spaces = 'newline';
+            } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $spaces = strlen($tokens[($stackPtr + 1)]['content']);
+            } else {
+                $spaces = 0;
+            }
+
+            if ($spaces !== 1) {
+                $error = 'Expected 1 space after FUNCTION keyword; %s found';
+                $data  = [$spaces];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterFunction', $data);
+                if ($fix === true) {
+                    if ($spaces === 0) {
+                        $phpcsFile->fixer->addContent($stackPtr, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    }
+                }
+            }
+        }//end if
+
+        // Must be no space before the opening parenthesis. For closures, this is
+        // enforced by the previous check because there is no content between the keywords
+        // and the opening parenthesis.
+        // Unfinished closures are tokenized as T_FUNCTION however, and can be excluded
+        // by checking for the scope_opener.
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION
+            && isset($tokens[$stackPtr]['scope_opener']) === true
+        ) {
+            if ($tokens[($openBracket - 1)]['content'] === $phpcsFile->eolChar) {
+                $spaces = 'newline';
+            } else if ($tokens[($openBracket - 1)]['code'] === T_WHITESPACE) {
+                $spaces = strlen($tokens[($openBracket - 1)]['content']);
+            } else {
+                $spaces = 0;
+            }
+
+            if ($spaces !== 0) {
+                $error = 'Expected 0 spaces before opening parenthesis; %s found';
+                $data  = [$spaces];
+                $fix   = $phpcsFile->addFixableError($error, $openBracket, 'SpaceBeforeOpenParen', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($openBracket - 1), '');
+                }
+            }
+        }//end if
+
+        // Must be one space before and after USE keyword for closures.
+        if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
+            $use = $phpcsFile->findNext(T_USE, ($closeBracket + 1), $tokens[$stackPtr]['scope_opener']);
+            if ($use !== false) {
+                if ($tokens[($use + 1)]['code'] !== T_WHITESPACE) {
+                    $length = 0;
+                } else if ($tokens[($use + 1)]['content'] === "\t") {
+                    $length = '\t';
+                } else {
+                    $length = strlen($tokens[($use + 1)]['content']);
+                }
+
+                if ($length !== 1) {
+                    $error = 'Expected 1 space after USE keyword; found %s';
+                    $data  = [$length];
+                    $fix   = $phpcsFile->addFixableError($error, $use, 'SpaceAfterUse', $data);
+                    if ($fix === true) {
+                        if ($length === 0) {
+                            $phpcsFile->fixer->addContent($use, ' ');
+                        } else {
+                            $phpcsFile->fixer->replaceToken(($use + 1), ' ');
+                        }
+                    }
+                }
+
+                if ($tokens[($use - 1)]['code'] !== T_WHITESPACE) {
+                    $length = 0;
+                } else if ($tokens[($use - 1)]['content'] === "\t") {
+                    $length = '\t';
+                } else {
+                    $length = strlen($tokens[($use - 1)]['content']);
+                }
+
+                if ($length !== 1) {
+                    $error = 'Expected 1 space before USE keyword; found %s';
+                    $data  = [$length];
+                    $fix   = $phpcsFile->addFixableError($error, $use, 'SpaceBeforeUse', $data);
+                    if ($fix === true) {
+                        if ($length === 0) {
+                            $phpcsFile->fixer->addContentBefore($use, ' ');
+                        } else {
+                            $phpcsFile->fixer->replaceToken(($use - 1), ' ');
+                        }
+                    }
+                }
+            }//end if
+        }//end if
+
+        if ($this->isMultiLineDeclaration($phpcsFile, $stackPtr, $openBracket, $tokens) === true) {
             $this->processMultiLineDeclaration($phpcsFile, $stackPtr, $tokens);
+        } else {
+            $this->processSingleLineDeclaration($phpcsFile, $stackPtr, $tokens);
         }
 
     }//end process()
+
+
+    /**
+     * Determine if this is a multi-line function declaration.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the current token
+     *                                                 in the stack passed in $tokens.
+     * @param int                         $openBracket The position of the opening bracket
+     *                                                 in the stack passed in $tokens.
+     * @param array                       $tokens      The stack of tokens that make up
+     *                                                 the file.
+     *
+     * @return void
+     */
+    public function isMultiLineDeclaration($phpcsFile, $stackPtr, $openBracket, $tokens)
+    {
+        $closeBracket = $tokens[$openBracket]['parenthesis_closer'];
+        if ($tokens[$openBracket]['line'] !== $tokens[$closeBracket]['line']) {
+            return true;
+        }
+
+        // Closures may use the USE keyword and so be multi-line in this way.
+        if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
+            $use = $phpcsFile->findNext(T_USE, ($closeBracket + 1), $tokens[$stackPtr]['scope_opener']);
+            if ($use !== false) {
+                // If the opening and closing parenthesis of the use statement
+                // are also on the same line, this is a single line declaration.
+                $open  = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($use + 1));
+                $close = $tokens[$open]['parenthesis_closer'];
+                if ($tokens[$open]['line'] !== $tokens[$close]['line']) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end isMultiLineDeclaration()
 
 
     /**
@@ -72,38 +226,40 @@ class CCHits_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffe
      *
      * Just uses the Generic BSD-Allman brace sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     * @param array                $tokens    The stack of tokens that make up
-     *                                        the file.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param array                       $tokens    The stack of tokens that make up
+     *                                               the file.
      *
      * @return void
      */
-    public function processSingleLineDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processSingleLineDeclaration($phpcsFile, $stackPtr, $tokens)
     {
-        if (class_exists('Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff', true) === false) {
-            throw new PHP_CodeSniffer_Exception('Class Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff not found');
+        if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
+            $sniff = new OpeningFunctionBraceKernighanRitchieSniff();
+        } else {
+            $sniff = new OpeningFunctionBraceBsdAllmanSniff();
         }
 
-        $sniff = new Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff();
+        $sniff->checkClosures = true;
         $sniff->process($phpcsFile, $stackPtr);
 
     }//end processSingleLineDeclaration()
 
 
     /**
-     * Processes mutli-line declarations.
+     * Processes multi-line declarations.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     * @param array                $tokens    The stack of tokens that make up
-     *                                        the file.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param array                       $tokens    The stack of tokens that make up
+     *                                               the file.
      *
      * @return void
      */
-    public function processMultiLineDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processMultiLineDeclaration($phpcsFile, $stackPtr, $tokens)
     {
         // We need to work out how far indented the function
         // declaration itself is, so we can work out how far to
@@ -111,115 +267,194 @@ class CCHits_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffe
         $functionIndent = 0;
         for ($i = ($stackPtr - 1); $i >= 0; $i--) {
             if ($tokens[$i]['line'] !== $tokens[$stackPtr]['line']) {
-                $i++;
                 break;
             }
         }
+
+        // Move $i back to the line the function is or to 0.
+        $i++;
 
         if ($tokens[$i]['code'] === T_WHITESPACE) {
             $functionIndent = strlen($tokens[$i]['content']);
         }
 
-        // Each line between the parenthesis should be indented 4 spaces.
-        $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
-        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
-        $lastLine     = $tokens[$openBracket]['line'];
-        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
-            if ($tokens[$i]['line'] !== $lastLine) {
-                if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
-                    // Closing brace needs to be indented to the same level
-                    // as the function.
-                    $expectedIndent = $functionIndent;
-                } else {
-                    $expectedIndent = ($functionIndent + 4);
-                }
-
-                // We changed lines, so this should be a whitespace indent token.
-                if ($tokens[$i]['code'] !== T_WHITESPACE) {
-                    $foundIndent = 0;
-                } else {
-                    $foundIndent = strlen($tokens[$i]['content']);
-                }
-
-                if ($expectedIndent !== $foundIndent) {
-                    $error = 'Multi-line function declaration not indented correctly; expected %s spaces but found %s';
-                    $data  = array(
-                              $expectedIndent,
-                              $foundIndent,
-                             );
-                    $phpcsFile->addError($error, $i, 'Indent', $data);
-                }
-
-                $lastLine = $tokens[$i]['line'];
-            }//end if
-
-            if ($tokens[$i]['code'] === T_ARRAY) {
-                // Skip arrays as they have their own indentation rules.
-                $i        = $tokens[$i]['parenthesis_closer'];
-                $lastLine = $tokens[$i]['line'];
-                continue;
-            }
-        }//end for
-
-        if (isset($tokens[$stackPtr]['scope_opener']) === true) {
-            // The openning brace needs to be one space away
-            // from the closing parenthesis.
-            $next = $tokens[($closeBracket + 1)];
-            if ($next['code'] !== T_WHITESPACE) {
-                $length = 0;
-            } else if ($next['content'] === $phpcsFile->eolChar) {
-                $length = -1;
-            } else {
-                $length = strlen($next['content']);
-            }
-
-            if ($length !== 1) {
-                $data = array($length);
-                $code = 'SpaceBeforeOpenBrace';
-
-                $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line function declaration; found ';
-                if ($length === -1) {
-                    $error .= 'newline';
-                    $code   = 'NewlineBeforeOpenBrace';
-                } else {
-                    $error .= '%s spaces';
-                }
-
-                $phpcsFile->addError($error, ($closeBracket + 1), $code, $data);
-                return;
-            }
-
-            // And just in case they do something funny before the brace...
-            $next = $phpcsFile->findNext(
-                T_WHITESPACE,
-                ($closeBracket + 1),
-                null,
-                true
-            );
-
-            if ($next !== false && $tokens[$next]['code'] !== T_OPEN_CURLY_BRACKET) {
-                $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line function declaration';
-                $phpcsFile->addError($error, $next, 'NoSpaceBeforeOpenBrace');
-            }
-        }//end if
-
         // The closing parenthesis must be on a new line, even
         // when checking abstract function definitions.
-        $prev = $phpcsFile->findPrevious(
+        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
+        $prev         = $phpcsFile->findPrevious(
             T_WHITESPACE,
             ($closeBracket - 1),
             null,
             true
         );
 
-        if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
-            $error = 'The closing parenthesis of a multi-line function declaration must be on a new line';
-            $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
+        if ($tokens[$closeBracket]['line'] !== $tokens[$tokens[$closeBracket]['parenthesis_opener']]['line']) {
+            if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
+                $error = 'The closing parenthesis of a multi-line function declaration must be on a new line';
+                $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'CloseBracketLine');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewlineBefore($closeBracket);
+                }
+            }
         }
+
+        // If this is a closure and is using a USE statement, the closing
+        // parenthesis we need to look at from now on is the closing parenthesis
+        // of the USE statement.
+        if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
+            $use = $phpcsFile->findNext(T_USE, ($closeBracket + 1), $tokens[$stackPtr]['scope_opener']);
+            if ($use !== false) {
+                $open         = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($use + 1));
+                $closeBracket = $tokens[$open]['parenthesis_closer'];
+
+                $prev = $phpcsFile->findPrevious(
+                    T_WHITESPACE,
+                    ($closeBracket - 1),
+                    null,
+                    true
+                );
+
+                if ($tokens[$closeBracket]['line'] !== $tokens[$tokens[$closeBracket]['parenthesis_opener']]['line']) {
+                    if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
+                        $error = 'The closing parenthesis of a multi-line use declaration must be on a new line';
+                        $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'UseCloseBracketLine');
+                        if ($fix === true) {
+                            $phpcsFile->fixer->addNewlineBefore($closeBracket);
+                        }
+                    }
+                }
+            }//end if
+        }//end if
+
+        // Each line between the parenthesis should be indented 4 spaces.
+        $openBracket = $tokens[$stackPtr]['parenthesis_opener'];
+        $lastLine    = $tokens[$openBracket]['line'];
+        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
+            if ($tokens[$i]['line'] !== $lastLine) {
+                if ($i === $tokens[$stackPtr]['parenthesis_closer']
+                    || ($tokens[$i]['code'] === T_WHITESPACE
+                    && (($i + 1) === $closeBracket
+                    || ($i + 1) === $tokens[$stackPtr]['parenthesis_closer']))
+                ) {
+                    // Closing braces need to be indented to the same level
+                    // as the function.
+                    $expectedIndent = $functionIndent;
+                } else {
+                    $expectedIndent = ($functionIndent + $this->indent);
+                }
+
+                // We changed lines, so this should be a whitespace indent token.
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $foundIndent = 0;
+                } else if ($tokens[$i]['line'] !== $tokens[($i + 1)]['line']) {
+                    // This is an empty line, so don't check the indent.
+                    $foundIndent = $expectedIndent;
+
+                    $error = 'Blank lines are not allowed in a multi-line function declaration';
+                    $fix   = $phpcsFile->addFixableError($error, $i, 'EmptyLine');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                } else {
+                    $foundIndent = strlen($tokens[$i]['content']);
+                }
+
+                if ($expectedIndent !== $foundIndent) {
+                    $error = 'Multi-line function declaration not indented correctly; expected %s spaces but found %s';
+                    $data  = [
+                        $expectedIndent,
+                        $foundIndent,
+                    ];
+
+                    $fix = $phpcsFile->addFixableError($error, $i, 'Indent', $data);
+                    if ($fix === true) {
+                        $spaces = str_repeat(' ', $expectedIndent);
+                        if ($foundIndent === 0) {
+                            $phpcsFile->fixer->addContentBefore($i, $spaces);
+                        } else {
+                            $phpcsFile->fixer->replaceToken($i, $spaces);
+                        }
+                    }
+                }
+
+                $lastLine = $tokens[$i]['line'];
+            }//end if
+
+            if ($tokens[$i]['code'] === T_ARRAY || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                // Skip arrays as they have their own indentation rules.
+                if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                    $i = $tokens[$i]['bracket_closer'];
+                } else {
+                    $i = $tokens[$i]['parenthesis_closer'];
+                }
+
+                $lastLine = $tokens[$i]['line'];
+                continue;
+            }
+        }//end for
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            return;
+        }
+
+        // The opening brace needs to be one space away from the closing parenthesis.
+        $opener = $tokens[$stackPtr]['scope_opener'];
+        if ($tokens[$opener]['line'] !== $tokens[$closeBracket]['line']) {
+            $error = 'The closing parenthesis and the opening brace of a multi-line function declaration must be on the same line';
+            $fix   = $phpcsFile->addFixableError($error, $opener, 'NewlineBeforeOpenBrace');
+            if ($fix === true) {
+                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), $closeBracket, true);
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addContent($prev, ' {');
+
+                // If the opener is on a line by itself, removing it will create
+                // an empty line, so just remove the entire line instead.
+                $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($opener - 1), $closeBracket, true);
+                $next = $phpcsFile->findNext(T_WHITESPACE, ($opener + 1), null, true);
+
+                if ($tokens[$prev]['line'] < $tokens[$opener]['line']
+                    && $tokens[$next]['line'] > $tokens[$opener]['line']
+                ) {
+                    // Clear the whole line.
+                    for ($i = ($prev + 1); $i < $next; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$opener]['line']) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+                    }
+                } else {
+                    // Just remove the opener.
+                    $phpcsFile->fixer->replaceToken($opener, '');
+                    if ($tokens[$next]['line'] === $tokens[$opener]['line']) {
+                        $phpcsFile->fixer->replaceToken(($opener + 1), '');
+                    }
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }//end if
+        } else {
+            $prev = $tokens[($opener - 1)];
+            if ($prev['code'] !== T_WHITESPACE) {
+                $length = 0;
+            } else {
+                $length = strlen($prev['content']);
+            }
+
+            if ($length !== 1) {
+                $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line function declaration; found %s spaces';
+                $fix   = $phpcsFile->addFixableError($error, ($opener - 1), 'SpaceBeforeOpenBrace', [$length]);
+                if ($fix === true) {
+                    if ($length === 0) {
+                        $phpcsFile->fixer->addContentBefore($opener, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($opener - 1), ' ');
+                    }
+                }
+
+                return;
+            }//end if
+        }//end if
 
     }//end processMultiLineDeclaration()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/.phpcs/CCHits/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -1,46 +1,33 @@
 <?php
 /**
- * CCHits_Sniffs_Functions_ValidDefaultValueSniff.
+ * Ensures function params with default values are at the end of the declaration.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ValidDefaultValueSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * CCHits_Sniffs_Functions_ValidDefaultValueSniff.
- *
- * A Sniff to ensure that parameters defined for a function that have a default
- * value come at the end of the function signature.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_Functions_ValidDefaultValueSniff implements PHP_CodeSniffer_Sniff
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ValidDefaultValueSniff implements Sniff
 {
 
 
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return int[]
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
 
     }//end register()
 
@@ -48,62 +35,44 @@ class CCHits_Sniffs_Functions_ValidDefaultValueSniff implements PHP_CodeSniffer_
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        $argStart = $tokens[$stackPtr]['parenthesis_opener'];
-        $argEnd   = $tokens[$stackPtr]['parenthesis_closer'];
-
         // Flag for when we have found a default in our arg list.
         // If there is a value without a default after this, it is an error.
         $defaultFound = false;
 
-        $nextArg = $argStart;
-        while (($nextArg = $phpcsFile->findNext(T_VARIABLE, ($nextArg + 1), $argEnd)) !== false) {
-            $argHasDefault = self::_argHasDefault($phpcsFile, $nextArg);
-            if (($argHasDefault === false) && ($defaultFound === true)) {
-                $error  = 'Arguments with default values must be at the end of the argument list';
-                $phpcsFile->addError($error, $nextArg, 'NotAtEnd');
-                return;
+        $params = $phpcsFile->getMethodParameters($stackPtr);
+        foreach ($params as $param) {
+            if ($param['variable_length'] === true) {
+                continue;
             }
 
-            if ($argHasDefault === true) {
+            if (array_key_exists('default', $param) === true) {
                 $defaultFound = true;
+                // Check if the arg is type hinted and using NULL for the default.
+                // This does not make the argument optional - it just allows NULL
+                // to be passed in.
+                if ($param['type_hint'] !== '' && strtolower($param['default']) === 'null') {
+                    $defaultFound = false;
+                }
+
+                continue;
             }
-        }
+
+            if ($defaultFound === true) {
+                $error = 'Arguments with default values must be at the end of the argument list';
+                $phpcsFile->addError($error, $param['token'], 'NotAtEnd');
+                return;
+            }
+        }//end foreach
 
     }//end process()
 
 
-    /**
-     * Returns true if the passed argument has a default value.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $argPtr    The position of the argument
-     *                                        in the stack.
-     *
-     * @return bool
-     */
-    private static function _argHasDefault(PHP_CodeSniffer_File $phpcsFile, $argPtr)
-    {
-        $tokens    = $phpcsFile->getTokens();
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($argPtr + 1), null, true);
-        if ($tokens[$nextToken]['code'] !== T_EQUAL) {
-            return false;
-        }
-
-        return true;
-
-    }//end _argHasDefault()
-
-
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/.phpcs/CCHits/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -1,35 +1,18 @@
 <?php
 /**
- * CCHits_Sniffs_NamingConventions_ValidClassNameSniff.
+ * Ensures class and interface names start with a capital letter and use _ separators.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ValidClassNameSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * CCHits_Sniffs_NamingConventions_ValidClassNameSniff.
- *
- * Ensures class and interface names start with a capital letter
- * and use _ separators.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeSniffer_Sniff
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ValidClassNameSniff implements Sniff
 {
 
 
@@ -40,10 +23,11 @@ class CCHits_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeSni
      */
     public function register()
     {
-        return array(
-                T_CLASS,
-                T_INTERFACE,
-               );
+        return [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+        ];
 
     }//end register()
 
@@ -51,24 +35,24 @@ class CCHits_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeSni
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being processed.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being processed.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         $className = $phpcsFile->findNext(T_STRING, $stackPtr);
         $name      = trim($tokens[$className]['content']);
-        $errorData = array(ucfirst($tokens[$stackPtr]['content']));
+        $errorData = [ucfirst($tokens[$stackPtr]['content'])];
 
         // Make sure the first letter is a capital.
         if (preg_match('|^[A-Z]|', $name) === 0) {
             $error = '%s name must begin with a capital letter';
-            $phpcsFile->addError($error, $stackPtr, 'StartWithCaptial', $errorData);
+            $phpcsFile->addError($error, $stackPtr, 'StartWithCapital', $errorData);
         }
 
         // Check that each new word starts with a capital as well, but don't
@@ -111,6 +95,3 @@ class CCHits_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeSni
 
 
 }//end class
-
-
-?>

--- a/.phpcs/CCHits/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/.phpcs/CCHits/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,50 +1,31 @@
 <?php
 /**
- * CCHits_Sniffs_NamingConventions_ValidVariableNameSniff.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ValidVariableNameSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === false) {
-    $error = 'Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
-
-/**
- * CCHits_Sniffs_NamingConventions_ValidVariableNameSniff.
- *
  * Checks the naming of member variables.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+
+class ValidVariableNameSniff extends AbstractVariableSniff
 {
 
 
     /**
      * Processes class member variables.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -54,17 +35,30 @@ class CCHits_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSni
         }
 
         $memberName     = ltrim($tokens[$stackPtr]['content'], '$');
-        $isPublic       = ($memberProps['scope'] === 'private') ? false : true;
         $scope          = $memberProps['scope'];
         $scopeSpecified = $memberProps['scope_specified'];
+
+        if ($memberProps['scope'] === 'private') {
+            $isPublic = false;
+        } else {
+            $isPublic = true;
+        }
+
+        // If it's a private member, it must have an underscore on the front.
+        if ($isPublic === false && $memberName{0} !== '_') {
+            $error = 'Private member variable "%s" must be prefixed with an underscore';
+            $data  = [$memberName];
+            $phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $data);
+            return;
+        }
 
         // If it's not a private member, it must not have an underscore on the front.
         if ($isPublic === true && $scopeSpecified === true && $memberName{0} === '_') {
             $error = '%s member variable "%s" must not be prefixed with an underscore';
-            $data  = array(
-                      ucfirst($scope),
-                      $memberName,
-                     );
+            $data  = [
+                ucfirst($scope),
+                $memberName,
+            ];
             $phpcsFile->addError($error, $stackPtr, 'PublicUnderscore', $data);
             return;
         }
@@ -75,15 +69,16 @@ class CCHits_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSni
     /**
      * Processes normal variables.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
      *
      * @return void
      */
-    protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processVariable(File $phpcsFile, $stackPtr)
     {
-        // We don't care about normal variables.
-        return;
+        /*
+            We don't care about normal variables.
+        */
 
     }//end processVariable()
 
@@ -91,19 +86,18 @@ class CCHits_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSni
     /**
      * Processes variables in double quoted strings.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
      *
      * @return void
      */
-    protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
     {
-        // We don't care about normal variables.
-        return;
+        /*
+            We don't care about normal variables.
+        */
 
     }//end processVariableInString()
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/.phpcs/CCHits/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -1,45 +1,37 @@
 <?php
 /**
- * CCHits_Sniffs_Whitespace_ScopeClosingBraceSniff.
- *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ScopeClosingBraceSniff.php 301632 2010-07-28 01:57:56Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-
-/**
- * CCHits_Sniffs_Whitespace_ScopeClosingBraceSniff.
- *
  * Checks that the closing braces of scopes are aligned correctly.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer_Sniff
+
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ScopeClosingBraceSniff implements Sniff
 {
 
-
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * The number of spaces code should be indented.
      *
-     * @return array
+     * @var integer
      */
+    public $indent = 4;
+
+
+     /**
+      * Returns an array of tokens this test wants to listen for.
+      *
+      * @return int[]
+      */
     public function register()
     {
-        return PHP_CodeSniffer_Tokens::$scopeOpeners;
+        return Tokens::$scopeOpeners;
 
     }//end register()
 
@@ -47,13 +39,13 @@ class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -63,13 +55,15 @@ class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer
             return;
         }
 
-        $scopeStart  = $tokens[$stackPtr]['scope_opener'];
-        $scopeEnd    = $tokens[$stackPtr]['scope_closer'];
+        $scopeStart = $tokens[$stackPtr]['scope_opener'];
+        $scopeEnd   = $tokens[$stackPtr]['scope_closer'];
 
         // If the scope closer doesn't think it belongs to this scope opener
-        // then the opener is sharing its closer ith other tokens. We only
+        // then the opener is sharing its closer with other tokens. We only
         // want to process the closer once, so skip this one.
-        if ($tokens[$scopeEnd]['scope_condition'] !== $stackPtr) {
+        if (isset($tokens[$scopeEnd]['scope_condition']) === false
+            || $tokens[$scopeEnd]['scope_condition'] !== $stackPtr
+        ) {
             return;
         }
 
@@ -84,20 +78,27 @@ class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer
             }
         }
 
-        // We found a new line, now go forward and find the first non-whitespace
-        // token.
-        $lineStart= $phpcsFile->findNext(
-            array(T_WHITESPACE),
-            ($lineStart + 1),
-            null,
-            true
-        );
+        $lineStart++;
 
-        $startColumn = $tokens[$lineStart]['column'];
+        $startColumn = 1;
+        if ($tokens[$lineStart]['code'] === T_WHITESPACE) {
+            $startColumn = $tokens[($lineStart + 1)]['column'];
+        } else if ($tokens[$lineStart]['code'] === T_INLINE_HTML) {
+            $trimmed = ltrim($tokens[$lineStart]['content']);
+            if ($trimmed === '') {
+                $startColumn = $tokens[($lineStart + 1)]['column'];
+            } else {
+                $startColumn = (strlen($tokens[$lineStart]['content']) - strlen($trimmed));
+            }
+        }
 
         // Check that the closing brace is on it's own line.
         $lastContent = $phpcsFile->findPrevious(
-            array(T_WHITESPACE),
+            [
+                T_WHITESPACE,
+                T_INLINE_HTML,
+                T_OPEN_TAG,
+            ],
             ($scopeEnd - 1),
             $scopeStart,
             true
@@ -105,34 +106,70 @@ class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer
 
         if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
             $error = 'Closing brace must be on a line by itself';
-            $phpcsFile->addError($error, $scopeEnd, 'Line');
+            $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'Line');
+            if ($fix === true) {
+                $phpcsFile->fixer->addNewlineBefore($scopeEnd);
+            }
+
             return;
         }
 
         // Check now that the closing brace is lined up correctly.
-        $braceIndent   = $tokens[$scopeEnd]['column'];
-        $isBreakCloser = ($tokens[$scopeEnd]['code'] === T_BREAK);
-        if (in_array($tokens[$stackPtr]['code'], array(T_CASE, T_DEFAULT)) === true
-            && $isBreakCloser === true
+        $lineStart = ($scopeEnd - 1);
+        for ($lineStart; $lineStart > 0; $lineStart--) {
+            if (strpos($tokens[$lineStart]['content'], $phpcsFile->eolChar) !== false) {
+                break;
+            }
+        }
+
+        $lineStart++;
+
+        $braceIndent = 0;
+        if ($tokens[$lineStart]['code'] === T_WHITESPACE) {
+            $braceIndent = ($tokens[($lineStart + 1)]['column'] - 1);
+        } else if ($tokens[$lineStart]['code'] === T_INLINE_HTML) {
+            $trimmed = ltrim($tokens[$lineStart]['content']);
+            if ($trimmed === '') {
+                $braceIndent = ($tokens[($lineStart + 1)]['column'] - 1);
+            } else {
+                $braceIndent = (strlen($tokens[$lineStart]['content']) - strlen($trimmed) - 1);
+            }
+        }
+
+        $fix = false;
+        if ($tokens[$stackPtr]['code'] === T_CASE
+            || $tokens[$stackPtr]['code'] === T_DEFAULT
         ) {
-            // BREAK statements should be indented 4 spaces from the
+            // BREAK statements should be indented n spaces from the
             // CASE or DEFAULT statement.
-            if ($braceIndent !== ($startColumn + 4)) {
-                $error = 'Break statement indented incorrectly; expected %s spaces, found %s';
-                $data  = array(
-                          ($startColumn + 3),
-                          ($braceIndent - 1),
-                         );
-                $phpcsFile->addError($error, $scopeEnd, 'BreakIdent', $data);
+            $expectedIndent = ($startColumn + $this->indent - 1);
+            if ($braceIndent !== $expectedIndent) {
+                $error = 'Case breaking statement indented incorrectly; expected %s spaces, found %s';
+                $data  = [
+                    $expectedIndent,
+                    $braceIndent,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'BreakIndent', $data);
             }
         } else {
-            if ($braceIndent !== $startColumn) {
+            $expectedIndent = max(0, ($startColumn - 1));
+            if ($braceIndent !== $expectedIndent) {
                 $error = 'Closing brace indented incorrectly; expected %s spaces, found %s';
-                $data  = array(
-                          ($startColumn - 1),
-                          ($braceIndent - 1),
-                         );
-                $phpcsFile->addError($error, $scopeEnd, 'Indent', $data);
+                $data  = [
+                    $expectedIndent,
+                    $braceIndent,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'Indent', $data);
+            }
+        }//end if
+
+        if ($fix === true) {
+            $spaces = str_repeat(' ', $expectedIndent);
+            if ($braceIndent === 0) {
+                $phpcsFile->fixer->addContentBefore($lineStart, $spaces);
+            } else {
+                $phpcsFile->fixer->replaceToken($lineStart, ltrim($tokens[$lineStart]['content']));
+                $phpcsFile->fixer->addContentBefore($lineStart, $spaces);
             }
         }
 
@@ -140,5 +177,3 @@ class CCHits_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer
 
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/.phpcs/CCHits/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -1,49 +1,24 @@
 <?php
 /**
- * CCHits_Sniffs_Whitespace_ScopeIndentSniff.
+ * Checks that control structures are structured and indented correctly.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   CVS: $Id: ScopeIndentSniff.php 254092 2008-03-03 02:51:39Z squiz $
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (class_exists('Generic_Sniffs_WhiteSpace_ScopeIndentSniff', true) === false) {
-    $error = 'Class Generic_Sniffs_WhiteSpace_ScopeIndentSniff not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+namespace PHP_CodeSniffer\Standards\CCHits\Sniffs\WhiteSpace;
 
-/**
- * CCHits_Sniffs_Whitespace_ScopeIndentSniff.
- *
- * Checks that control structures are structured correctly, and their content
- * is indented correctly.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @version   Release: 1.3.0
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class CCHits_Sniffs_WhiteSpace_ScopeIndentSniff extends Generic_Sniffs_WhiteSpace_ScopeIndentSniff
+use PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff as GenericScopeIndentSniff;
+
+class ScopeIndentSniff extends GenericScopeIndentSniff
 {
 
     /**
      * Any scope openers that should not cause an indent.
      *
-     * @var array(int)
+     * @var int[]
      */
-    protected $nonIndentingScopes = array(T_SWITCH);
+    protected $nonIndentingScopes = [T_SWITCH];
 
 }//end class
-
-?>

--- a/.phpcs/CCHits/ruleset.xml
+++ b/.phpcs/CCHits/ruleset.xml
@@ -11,10 +11,10 @@
  <rule ref="Generic.Commenting.DocComment"/>
  <rule ref="Squiz.Commenting.DocCommentAlignment"/>
 
- <!-- Lines can be 85 chars long, but never show errors -->
+ <!-- Lines can be 120 chars long, but never show errors -->
  <rule ref="Generic.Files.LineLength">
   <properties>
-   <property name="lineLimit" value="85"/>
+   <property name="lineLimit" value="120"/>
    <property name="absoluteLineLimit" value="0"/>
   </properties>
  </rule>

--- a/.phpcs/CCHits/ruleset.xml
+++ b/.phpcs/CCHits/ruleset.xml
@@ -1,9 +1,41 @@
 <?xml version="1.0"?>
-<!DOCTYPE ruleset [
-  <!ELEMENT ruleset (description?)>
-  <!ELEMENT description (#PCDATA)>
-  	<!ATTLIST ruleset name CDATA "default">
-]>
 <ruleset name="CCHits">
- <description>Coding standard for CCHits.net.</description>
+ <description>The CCHits coding standard.</description>
+
+ <!-- Include some additional sniffs from the Generic standard -->
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+ <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+ <rule ref="Generic.PHP.LowerCaseConstant"/>
+ <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+ <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+ <rule ref="Generic.Commenting.DocComment"/>
+ <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+
+ <!-- Lines can be 85 chars long, but never show errors -->
+ <rule ref="Generic.Files.LineLength">
+  <properties>
+   <property name="lineLimit" value="85"/>
+   <property name="absoluteLineLimit" value="0"/>
+  </properties>
+ </rule>
+
+ <!-- Use Unix newlines -->
+ <rule ref="Generic.Files.LineEndings">
+  <properties>
+   <property name="eolChar" value="\n"/>
+  </properties>
+ </rule>
+
+ <!-- This message is not required as spaces are allowed for alignment -->
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
+  <severity>0</severity>
+ </rule>
+
+ <!-- Use warnings for inline control structures -->
+ <rule ref="Generic.ControlStructures.InlineControlStructure">
+  <properties>
+   <property name="error" value="false"/>
+  </properties>
+ </rule>
+
 </ruleset>


### PR DESCRIPTION
I took the PEAR standard, and changed the max line length to 120.
We can now run `phpcs --standard=/path/to/repo/.phpcs/CCHits /path/to/repo/CLASSES`