### PR TITLE
Fixed PDO bug + some coding standards

### DIFF
--- a/CLASSES/class_GenericObject.php
+++ b/CLASSES/class_GenericObject.php
@@ -101,16 +101,11 @@ class GenericObject
                         $sql .= ", ";
                     }
                     $sql .= "$change_key = :$change_key";
-                    if ($this->$change_key === true)
-                    {
+                    if ($this->$change_key === true) {
                         $values[$change_key] = 1;
-                    }
-                    elseif ($this->$change_key === false)
-                    {
+                    } elseif ($this->$change_key === false) {
                         $values[$change_key] = 0;
-                    }
-                    else
-                    {
+                    } else {
                         $values[$change_key] = $this->$change_key;
                     }
                 }
@@ -123,7 +118,11 @@ class GenericObject
                 // This section of code, thanks to code example here:
                 // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
                 if ($query->errorCode() != 0) {
-                    throw new Exception("SQL Error: " . print_r(array('sql'=>$full_sql, 'values'=>$values, 'error'=>$query->errorInfo()), true), 1);
+                    throw new Exception(
+                        "SQL Error: " . print_r(
+                            array('sql'=>$full_sql, 'values'=>$values, 'error'=>$query->errorInfo()), true
+                        ), 1
+                    );
                 }
                 return true;
             } catch(Exception $e) {
@@ -150,7 +149,11 @@ class GenericObject
             }
             $keys .= $field_name;
             $key_place .= ":$field_name";
-            $values[$field_name] = $this->$field_name;
+            if (is_bool($this->$field_name)) {
+                $values[$field_name] = (int) $this->$field_name;
+            } else {
+                $values[$field_name] = $this->$field_name;
+            }
         }
         $full_sql = "INSERT INTO {$this->strDBTable} ($keys) VALUES ($key_place)";
         try {
@@ -160,7 +163,11 @@ class GenericObject
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$full_sql, 'values'=>$values, 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array('sql'=>$full_sql, 'values'=>$values, 'error'=>$query->errorInfo()), true
+                    ), 1
+                );
             }
             if ($this->strDBKeyCol != '') {
                 $key = $this->strDBKeyCol;

--- a/CLASSES/class_TrackBroker.php
+++ b/CLASSES/class_TrackBroker.php
@@ -37,7 +37,7 @@ class TrackBroker
      *
      * @return object This class by itself.
      */
-    private static function getHandler()
+    private static function _getHandler()
     {
         if (self::$handler == null) {
             self::$handler = new self();
@@ -52,7 +52,7 @@ class TrackBroker
      */
     public static function getTotalTracks()
     {
-        $th = self::getHandler();
+        $th = self::_getHandler();
         if (isset($th->intTotalTracks) and $th->intTotalTracks != 0) {
             return $th->intTotalTracks;
         }
@@ -83,7 +83,7 @@ class TrackBroker
      */
     public static function getTrackByID($intTrackID = 0)
     {
-        $handler = self::getHandler();
+        $handler = self::_getHandler();
         if (isset($handler->arrTracks[$intTrackID]) and $handler->arrTracks[$intTrackID] != false) {
             return $handler->arrTracks[$intTrackID];
         }
@@ -95,7 +95,11 @@ class TrackBroker
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>$intTrackID, 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array('sql'=>$sql, 'values'=>$intTrackID, 'error'=>$query->errorInfo()), true
+                    ), 1
+                );
             }
             $handler->arrTracks[$intTrackID] = $query->fetchObject('TrackObject');
             return $handler->arrTracks[$intTrackID];
@@ -133,9 +137,8 @@ class TrackBroker
             $intSize = 25;
         }
 
-        if ($strSort == null and isset($arrUri['parameters']['sort'])) {
-            if ($arrUri['parameters']['sort'] == 'intTrackID' ||
-                $arrUri['parameters']['sort'] == 'strTrackName') {
+        if ((!isset($strSort) or ($strSort == null)) and isset($arrUri['parameters']['sort'])) {
+            if ($arrUri['parameters']['sort'] == 'intTrackID' || $arrUri['parameters']['sort'] == 'strTrackName') {
                 $strSort = $arrUri['parameters']['sort'];
             } else {
                 $strSort = 'intTrackID';
@@ -144,7 +147,7 @@ class TrackBroker
             $strSort = 'intTrackID';
         }
 
-        if ($strDirection == null and isset($arrUri['parameters']['direction'])) {
+        if ((!isset($strDirection) or ($strDirection == null)) and isset($arrUri['parameters']['direction'])) {
             if ($arrUri['parameters']['direction'] == 'desc') {
                 $strDirection = 'DESC';
             } else {
@@ -156,7 +159,8 @@ class TrackBroker
 
         $db = Database::getConnection();
         try {
-            $sql = "SELECT * FROM tracks WHERE strTrackName REGEXP ? OR strTrackName REGEXP ? ORDER BY " . $strSort . " " . $strDirection;
+            $sql = "SELECT * FROM tracks WHERE strTrackName REGEXP ? "
+                . "OR strTrackName REGEXP ? ORDER BY " . $strSort . " " . $strDirection;
             $pagestart = ($intPage*$intSize);
             $query = $db->prepare($sql . " LIMIT " . $pagestart . ", $intSize");
             // This snippet from http://www.php.net/manual/en/function.str-split.php
@@ -189,9 +193,18 @@ class TrackBroker
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>array("\"{$strTrackName}[[:space:]]*\"", "{$strTrackName}[[:space:]]*"), 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array(
+                            'sql'=>$sql, 
+                            'values'=>array("\"{$strTrackName}[[:space:]]*\"",
+                            "{$strTrackName}[[:space:]]*"),
+                            'error'=>$query->errorInfo()
+                        ), true
+                    ), 1
+                );
             }
-            $handler = self::getHandler();
+            $handler = self::_getHandler();
             $item = $query->fetchObject('TrackObject');
             if ($item == false) {
                 return false;
@@ -237,8 +250,7 @@ class TrackBroker
             $intSize = 25;
         }
         if ($strSort == null and isset($arrUri['parameters']['sort'])) {
-            if ($arrUri['parameters']['sort'] == 'intTrackID' ||
-                $arrUri['parameters']['sort'] == 'strTrackName') {
+            if ($arrUri['parameters']['sort'] == 'intTrackID' || $arrUri['parameters']['sort'] == 'strTrackName') {
                 $strSort = $arrUri['parameters']['sort'];
             } else {
                 $strSort = 'intTrackID';
@@ -292,9 +304,17 @@ class TrackBroker
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>".*{$strTrackName}[[:space:]]*.*", 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array(
+                            'sql'=>$sql,
+                            'values'=>".*{$strTrackName}[[:space:]]*.*",
+                            'error'=>$query->errorInfo()
+                        ), true
+                    ), 1
+                );
             }
-            $handler = self::getHandler();
+            $handler = self::_getHandler();
             $item = $query->fetchObject('TrackObject');
             if ($item == false) {
                 return false;
@@ -339,8 +359,7 @@ class TrackBroker
         }
 
         if ($strSort == null and isset($arrUri['parameters']['sort'])) {
-            if ($arrUri['parameters']['sort'] == 'intTrackID' ||
-                $arrUri['parameters']['sort'] == 'strTrackName') {
+            if ($arrUri['parameters']['sort'] == 'intTrackID' || $arrUri['parameters']['sort'] == 'strTrackName') {
                 $strSort = $arrUri['parameters']['sort'];
             } else {
                 $strSort = 'intTrackID';
@@ -361,7 +380,8 @@ class TrackBroker
 
         $db = Database::getConnection();
         try {
-            $sql = "SELECT * FROM tracks WHERE strTrackUrl LIKE ? or strTrackUrl LIKE ? ORDER BY " . $strSort . " " . $strDirection;
+            $sql = "SELECT * FROM tracks WHERE strTrackUrl LIKE ? or strTrackUrl LIKE ? ORDER BY " 
+                . $strSort . " " . $strDirection;
             $pagestart = ($intPage*$intSize);
             $query = $db->prepare($sql . " LIMIT " . $pagestart . ", $intSize");
             // For tracks have this field as a serialized json array, in which "/" are escaped with "\", 
@@ -369,18 +389,28 @@ class TrackBroker
             // "preferred":"http:\/\/archive.org\/details\/enrmp272_the_easton_ellises_-_ep_one"}
             // MySQL wants "\"s to be escaped, so that's "\\" for one "\". But PHP also wants "\"s to be escaped... 
             // Hence "\\\\" : this is sent as "\\" to MySQL which then interprets that as the literal "\" character.
-            // BUT... for tracks with only one URL, it is stored as a non escaped string, ie : http://www.jamendo.com/en/track/806979
+            // BUT... for tracks with only one URL, it is stored as a non escaped string, 
+            // ie : http://www.jamendo.com/en/track/806979
             // Hence the "or" operator in the $sql above.
-            // Addendum : some tracks have this field stored as a JSON array, ie : ["http:\/\/www.jamendo.com\/en\/track\/1026956"].
+            // Addendum : some tracks have this field stored as a JSON array, 
+            // ie : ["http:\/\/www.jamendo.com\/en\/track\/1026956"].
             // The replacement bellow will also work for those.
             $strEscapedTrackUrl = str_replace("/", "\\\\/", $strTrackUrl);
             $query->execute(array("%$strTrackUrl%", "%$strEscapedTrackUrl%"));
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>array("\"$strTrackUrl%", $strTrackUrl . '%'), 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array(
+                            'sql'=>$sql,
+                            'values'=>array("\"$strTrackUrl%", $strTrackUrl . '%'),
+                            'error'=>$query->errorInfo()),
+                        true
+                    ), 1
+                );
             }
-            $handler = self::getHandler();
+            $handler = self::_getHandler();
             $item = $query->fetchObject('TrackObject');
             if ($item == false) {
                 return false;
@@ -415,9 +445,19 @@ class TrackBroker
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>array('%"' . $strTrackUrl . '"%', $strTrackUrl), 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array(
+                            'sql'=>$sql,
+                            'values'=>array('%"' . $strTrackUrl . '"%', $strTrackUrl),
+                            'error'=>$query->errorInfo()
+                        ),
+                        true
+                    ),
+                    1
+                );
             }
-            $handler = self::getHandler();
+            $handler = self::_getHandler();
             $item = $query->fetchObject('TrackObject');
             if ($item == false) {
                 return false;
@@ -452,9 +492,13 @@ class TrackBroker
             // This section of code, thanks to code example here:
             // http://www.lornajane.net/posts/2011/handling-sql-errors-in-pdo
             if ($query->errorCode() != 0) {
-                throw new Exception("SQL Error: " . print_r(array('sql'=>$sql, 'values'=>$md5FileHash, 'error'=>$query->errorInfo()), true), 1);
+                throw new Exception(
+                    "SQL Error: " . print_r(
+                        array('sql'=>$sql, 'values'=>$md5FileHash, 'error'=>$query->errorInfo()), true
+                    ), 1
+                );
             }
-            $handler = self::getHandler();
+            $handler = self::_getHandler();
             $item = $query->fetchObject('TrackObject');
             if ($item == false) {
                 return false;


### PR DESCRIPTION
So PDO has a bug in recent versions of PHP : 
```php
$sql = "INSERT INTO myTable(boolColumn) VALUES (:boolValue)";
$value = ["boolValue" => FALSE];
$query = $db->prepare($sql);
$query->execute($values);
```
ends up as : 
```sql
INSERT INTO myTable(boolColumn) VALUES ('')
```
The commonly accepted workaround is to cast boolean values to int.