### PR TITLE
Fixed : added configuration option to choose the location of the upload directory

### DIFF
--- a/CLASSES/class_RemoteSources.php
+++ b/CLASSES/class_RemoteSources.php
@@ -827,7 +827,7 @@ class RemoteSources extends GenericObject
         //curl_setopt($ch, CURLOPT_VERBOSE, true);
 
         if ($as_file == 1) {
-            $tempname = GeneralFunctions::getTempFileName(dirname(__FILE__) . '/../upload/');
+            $tempname = GeneralFunctions::getTempFileName(ConfigBroker::getConfig('uploadBase', dirname(__FILE__) . '/../upload/'));
             if ($tempname == false) {
                 error_log("Wasn't able to create a temporary file for uploading");
                 unlink($cookie);


### PR DESCRIPTION
I check my code using a `trusty64` image inside `Virtualbox` because I don't have `php5` on my machine.
I found out that `php_curl` as difficulties writing files on a ?`Virtualbox`'s sync'ed folder.
This configuration option allows to change the location of the folder in which `php_curl` uploads files (in my case, the tracks pulled from Jamendo).
There is no need to add a value in the `config` table, as the default value matches what is used right now on the live server.
