### PR TITLE
Working on issue #89 

### DIFF
--- a/CSS/cchits-extra.css
+++ b/CSS/cchits-extra.css
@@ -95,7 +95,7 @@ a:hover {
     border-bottom: 1px solid gray;
     padding: 5px 0;
 }
-
+.container a,
 .chart-track a {
     border-bottom: 1px solid #404040;
 }

--- a/TEMPLATES/Source/about.html.tpl
+++ b/TEMPLATES/Source/about.html.tpl
@@ -1,104 +1,100 @@
-<html>
-	<head>
-    <meta name=viewport content="width=device-width, initial-scale=1">
-		<title>About: {$ServiceName} - {$Slogan}</title>
-	</head>
-	<body>
-		<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
-		<h2>{$Slogan}</h2>
-		<h3>About CCHits.net, the FAQ and more</h3>
-		<ul class="TOC">
-			<li><a href="#goals">Goals</a></li>
-			<li><a href="#source">Source</a></li>
-			<li><a href="#database">Database</a></li>
-			<li><a href="#api">API</a></li>
-			<li><a href="#voteadjust">Vote Adjustments</a></li>
-			<li><a href="#trends">Trending Data</a></li>
-			<li><a href="#theme">Theme</a></li>
-                        <li><a href="#nsfw">Not Safe for Work or Family Listening - an explanation</a></li>
+{extends file="partials/_layout.html.tpl"}
+{block name=title}About: {$ServiceName} - {$Slogan}{/block}
+{block name=content}
+	<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
+	<h2>{$Slogan}</h2>
+	<h3>About CCHits.net, the FAQ and more</h3>
+	<ul class="TOC">
+		<li><a href="#goals">Goals</a></li>
+		<li><a href="#source">Source</a></li>
+		<li><a href="#database">Database</a></li>
+		<li><a href="#api">API</a></li>
+		<li><a href="#voteadjust">Vote Adjustments</a></li>
+		<li><a href="#trends">Trending Data</a></li>
+		<li><a href="#theme">Theme</a></li>
+		<li><a href="#nsfw">Not Safe for Work or Family Listening - an explanation</a></li>
+	</ul>
+	<div class="FAQItem">
+		<a name="goals"></a>
+		<h3>Goals</h3>
+		<p>CCHits.net is a site promoting and featuring <a href="http://creativecommons.org/about/licenses/">Creative Commons</a> licensed music and the podcasts that play them. The site was designed with more than just this in mind. Here are some of the highlights</p>
+	
+		<ul>
+			<li>
+				<h4>Encourage and Discover Great Music</h4>
+				<p>There's a lot of great Creative Commons Licensed Music out there, and not enough people know just what you can get hold of! To help ease the burdon of this issue, there are three things that we do:</p>
+				<ul>
+					<li>By linking directly to artist's home sites rather than to our own holding pages for artists, we ensure that the artists get maximum exposure for their own material, without having to update our site when their own information changes!</li>
+					<li>By linking to the source of the individual track, gives listeners a greater awareness of music sources, which hopefully should increase the exposure for sites who promote and list Creative Commons licensed music.</li>
+					<li>By linking to podcasts which play Creative Commons licensed music, we give listeners the opportunity to find other shows that play the music they like - ultimately giving listeners a greater fountain of great music to select from, and hopefully giving them the opportunity to discover new artists and genres to add to their personal list of favourites.</li>
+				</ul>
+			</li>
+			<li>
+				<h4>Support Communities</h4>
+				<p>An attendor at various social groups, the original author of the code which drives cchits.net was unable to provide consistent, suitable background music for events he was involved in organising or just attending. This site was originally designed to find tracks which are generally acceptable for public play, and are available under a suitable license for public performance (which Creative Commons music should be!) By asking all submitters of music to identify the license under which the tracks are made available, as well as selecting whether tracks may not be suitable for work or family listening, it should be possible (once the code is in-place) to request from the site a suitable selection of music for playback at venues such as hackspaces, youth centres, or even just hold music for a business. Note that this site is not being created to build a re-licensing business, but instead to promote awareness of great music - there are other, better sites, that can advise and assist in the selection of Creative Commons music which are suitable for your business endeavour, but if you just want something for backing music for an hour or a whole day, this site might be (eventually!) just the thing for you.</p>
+			</li>
+			
+			<li>
+				<h4>Create Podcasts and Improve Coding Techniques</h4>
+				<p>At the time of writing, cchits.net is the work of one person. For several months, <a href="http://jon.sprig.gs">Jon "The Nice Guy" Spriggs</a> had been considering starting a podcast, however, he's not exactly known for finishing projects! By making a system which is automated enough to create a daily podcast, a weekly podcast and a monthly podcast, playing music that he likes to hear, he thought it might encourage him to stick to it - especially when there are other amazing goals (see above) which come out as a side benefit. He normally has described himself as a writer of "bad PHP code", and each project he starts improves the techniques he has learned.</p>
+				<p>In this instance, CCHits.net has introduced Jon to the concept of writing an API that works, a system of remote execution of code, the generation of synthesized speech and the generation of an audio track, entirely in code! Never being shy of criticism from the community, especially where code is concerned, the code has all been released under a license which encourages reuse and requires the code is re-released under the same license.</p>
+			</li>
 		</ul>
-		<div class="FAQItem">
-			<a name="goals"></a>
-			<h3>Goals</h3>
-		    <p>CCHits.net is a site promoting and featuring <a href="http://creativecommons.org/about/licenses/">Creative Commons</a> licensed music and the podcasts that play them. The site was designed with more than just this in mind. Here are some of the highlights</p>
-		
-		    <ul>
-				<li>
-					<h4>Encourage and Discover Great Music</h4>
-					<p>There's a lot of great Creative Commons Licensed Music out there, and not enough people know just what you can get hold of! To help ease the burdon of this issue, there are three things that we do:</p>
-					<ul>
-						<li>By linking directly to artist's home sites rather than to our own holding pages for artists, we ensure that the artists get maximum exposure for their own material, without having to update our site when their own information changes!</li>
-						<li>By linking to the source of the individual track, gives listeners a greater awareness of music sources, which hopefully should increase the exposure for sites who promote and list Creative Commons licensed music.</li>
-						<li>By linking to podcasts which play Creative Commons licensed music, we give listeners the opportunity to find other shows that play the music they like - ultimately giving listeners a greater fountain of great music to select from, and hopefully giving them the opportunity to discover new artists and genres to add to their personal list of favourites.</li>
-					</ul>
-				</li>
-				<li>
-					<h4>Support Communities</h4>
-					<p>An attendor at various social groups, the original author of the code which drives cchits.net was unable to provide consistent, suitable background music for events he was involved in organising or just attending. This site was originally designed to find tracks which are generally acceptable for public play, and are available under a suitable license for public performance (which Creative Commons music should be!) By asking all submitters of music to identify the license under which the tracks are made available, as well as selecting whether tracks may not be suitable for work or family listening, it should be possible (once the code is in-place) to request from the site a suitable selection of music for playback at venues such as hackspaces, youth centres, or even just hold music for a business. Note that this site is not being created to build a re-licensing business, but instead to promote awareness of great music - there are other, better sites, that can advise and assist in the selection of Creative Commons music which are suitable for your business endeavour, but if you just want something for backing music for an hour or a whole day, this site might be (eventually!) just the thing for you.</p>
-				</li>
-				
-				<li>
-					<h4>Create Podcasts and Improve Coding Techniques</h4>
-					<p>At the time of writing, cchits.net is the work of one person. For several months, <a href="http://jon.sprig.gs">Jon "The Nice Guy" Spriggs</a> had been considering starting a podcast, however, he's not exactly known for finishing projects! By making a system which is automated enough to create a daily podcast, a weekly podcast and a monthly podcast, playing music that he likes to hear, he thought it might encourage him to stick to it - especially when there are other amazing goals (see above) which come out as a side benefit. He normally has described himself as a writer of "bad PHP code", and each project he starts improves the techniques he has learned.</p>
-					<p>In this instance, CCHits.net has introduced Jon to the concept of writing an API that works, a system of remote execution of code, the generation of synthesized speech and the generation of an audio track, entirely in code! Never being shy of criticism from the community, especially where code is concerned, the code has all been released under a license which encourages reuse and requires the code is re-released under the same license.</p>
-				</li>
-		    </ul>
-		</div>
-		<div class="GetInvolved">
-			<a name="getinvolved"></a>
-			<h3>Get Involved</h3>
-			<p>If you want to get involved, please contact <a href="mailto:show@cchits.net">show@cchits.net</a> to talk about submitting tracks, creating shows and generally doing more with CCHits.net</p>
-		</div>
-		<div class="FAQItem">
-			<a name="source"></a>
-			<h3>Source</h3>
-			<p>The source code for everything driving this site is available in the Git Repositories at <a href="http://github.com/cchits/website">Github</a>.</p>
-			<p>Patches to either can either be e-mailed to <a href="mailto:code@cchits.net">code@cchits.net</a>, or you can clone a repository, make your changes and then raise a merge request through the site.</p>
-			<h3>Developers</h3>
-			<p>Thinking of working with the source code, API or website? Have a look at <a href="https://github.com/CCHits/Website/wiki">the development site</a>.</p>
-		</div>
-		<div class="FAQItem">
-			<a name="database"></a>
-			<h3>Database</h3>
-			<p>I was inspired by the <a href="http://ur1.ca">ur1.ca</a> folk, that giving away access to your database is almost as powerful as the service you're already providing. To try and achieve what they do, from this page, you can request an export of the database, albeit with one factor sanitized... the users table. There are two columns, containing the OpenID Claimed Identity page, and the Username and Password hash used to perform API calls. Both of these will be hashed before sending, to help keep user records secure.</p>
-			<form action="{$baseURL}about/database" method="post">
-			<input type="submit" name="go" value="Give me the database!" />
-			</form>
-			<p><b>This DATABASE and it's DATA is made available under the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero license</a>.</b></p>
-		</div>
-		<div class="FAQItem">
-			<a name="api"></a>
-			<h3>API</h3>
-			<p>Please see the <a href="https://github.com/CCHits/Website/wiki/Using-the-API">full API documentation</a>.</p>
-		</div>
-		<div class="FAQItem">
-			<a name="voteadjust"></a>
-			<h3>Vote Adjustments</h3>
-		    <p>CCHits.net adjusts the votes accrued when weekly review shows and monthly chart shows are released. In both cases, this is to try and ensure that generated shows don't constantly repeat the same tracks that became popular at the start of the system.</p>
-		    <p>Each time a track appears on a weekly or monthly show, it is adjusted down by 5%. No plays by external podcasts or the daily exposure show will influence the votes received by that track.</p>
-		    <p>To see the shows that have played a track, you can click on the track listing for the track on any of the show listings, and it will list all the shows we know about.</p>
-		</div>
-		<div class="FAQItem">
-			<a name="trends"></a>
-			<h3>Trending Data</h3>
-		    <p>CCHits.net monitors trending information about tracks which are being voted upon. This is done by a very simple formula - the votes for each 24 hour period is collated and multiplied by an incrementing number to correspond with the number of days the surveyed sample covers. A single vote placed on each of the 7 days in the searched period will be equivelent to 1 vote on the first day, 2 on the second, 3 on the third and so on. Each search covers 7 days.</p>
-		</div>
-		<div class="FAQItem">
-			<a name="theme"></a>
-			<h3>Theme</h3>
-			<p>The theme is an exerpt from a track, sourced from <a href="http://ccmixter.org/">ccMixter</a>. The Track is called <a href="http://ccmixter.org/files/scottaltham/19726">GMZ</a> and was created by <a href="http://ccmixter.org/people/scottaltham">scottaltham</a>.</p>
-		</div>
-		<div class="FAQItem">
-			<a name="nsfw"></a>
-			<h3>Not Safe for Work or Family Listening - an explanation</h3>
-			<p>As this project was originally supposed to create audio to be used at events, I wanted to be clear about the demarkation between "Work-or-Family Safe" music, and non... so I drew up these guidelines. A track is safe for work-or-family listening if:</p>
-                        <ul>
-                            <li>The track does not contain any swear words or derogatory words for gender, race, preference, or if it does contain them, they are hard to make out or distinguish.</li>
-                            <li>The track does not contain any obvious direct references to drug use.</li>
-                            <li>The track does not contain any obvious sexual references, including suggestive sounds.</li>
-                            <li>The track does not advocate crime or gun use (which is a criminal act in some countries).</li>
-                        </ul>
-                        <p>Obviously, not everyone agrees with this definition, and I don't upload every track. Some people will mark a track as being non-work-safe if it contains language they don't understand (in case it breaches one of the recommendations), or will mark a track as being work-or-family safe even if it breaches one of the above recommendations. If you disagree with how the track is marked, please feel free to contact <a href="mailto:show@cchits.net">show@cchits.net</a> and I'll re-listen to the track, and possibly change it's flag, if I think it's appropriate.</p>
-		</div>
-	</body>
-</html>
+	</div>
+	<div class="GetInvolved">
+		<a name="getinvolved"></a>
+		<h3>Get Involved</h3>
+		<p>If you want to get involved, please contact <a href="mailto:show@cchits.net">show@cchits.net</a> to talk about submitting tracks, creating shows and generally doing more with CCHits.net</p>
+	</div>
+	<div class="FAQItem">
+		<a name="source"></a>
+		<h3>Source</h3>
+		<p>The source code for everything driving this site is available in the Git Repositories at <a href="http://github.com/cchits/website">Github</a>.</p>
+		<p>Patches to either can either be e-mailed to <a href="mailto:code@cchits.net">code@cchits.net</a>, or you can clone a repository, make your changes and then raise a merge request through the site.</p>
+		<h3>Developers</h3>
+		<p>Thinking of working with the source code, API or website? Have a look at <a href="https://github.com/CCHits/Website/wiki">the development site</a>.</p>
+	</div>
+	<div class="FAQItem">
+		<a name="database"></a>
+		<h3>Database</h3>
+		<p>I was inspired by the <a href="http://ur1.ca">ur1.ca</a> folk, that giving away access to your database is almost as powerful as the service you're already providing. To try and achieve what they do, from this page, you can request an export of the database, albeit with one factor sanitized... the users table. There are two columns, containing the OpenID Claimed Identity page, and the Username and Password hash used to perform API calls. Both of these will be hashed before sending, to help keep user records secure.</p>
+		<form action="{$baseURL}about/database" method="post">
+		<input type="submit" name="go" value="Give me the database!" />
+		</form>
+		<p><b>This DATABASE and it's DATA is made available under the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero license</a>.</b></p>
+	</div>
+	<div class="FAQItem">
+		<a name="api"></a>
+		<h3>API</h3>
+		<p>Please see the <a href="https://github.com/CCHits/Website/wiki/Using-the-API">full API documentation</a>.</p>
+	</div>
+	<div class="FAQItem">
+		<a name="voteadjust"></a>
+		<h3>Vote Adjustments</h3>
+		<p>CCHits.net adjusts the votes accrued when weekly review shows and monthly chart shows are released. In both cases, this is to try and ensure that generated shows don't constantly repeat the same tracks that became popular at the start of the system.</p>
+		<p>Each time a track appears on a weekly or monthly show, it is adjusted down by 5%. No plays by external podcasts or the daily exposure show will influence the votes received by that track.</p>
+		<p>To see the shows that have played a track, you can click on the track listing for the track on any of the show listings, and it will list all the shows we know about.</p>
+	</div>
+	<div class="FAQItem">
+		<a name="trends"></a>
+		<h3>Trending Data</h3>
+		<p>CCHits.net monitors trending information about tracks which are being voted upon. This is done by a very simple formula - the votes for each 24 hour period is collated and multiplied by an incrementing number to correspond with the number of days the surveyed sample covers. A single vote placed on each of the 7 days in the searched period will be equivelent to 1 vote on the first day, 2 on the second, 3 on the third and so on. Each search covers 7 days.</p>
+	</div>
+	<div class="FAQItem">
+		<a name="theme"></a>
+		<h3>Theme</h3>
+		<p>The theme is an exerpt from a track, sourced from <a href="http://ccmixter.org/">ccMixter</a>. The Track is called <a href="http://ccmixter.org/files/scottaltham/19726">GMZ</a> and was created by <a href="http://ccmixter.org/people/scottaltham">scottaltham</a>.</p>
+	</div>
+	<div class="FAQItem">
+		<a name="nsfw"></a>
+		<h3>Not Safe for Work or Family Listening - an explanation</h3>
+		<p>As this project was originally supposed to create audio to be used at events, I wanted to be clear about the demarkation between "Work-or-Family Safe" music, and non... so I drew up these guidelines. A track is safe for work-or-family listening if:</p>
+		<ul>
+			<li>The track does not contain any swear words or derogatory words for gender, race, preference, or if it does contain them, they are hard to make out or distinguish.</li>
+			<li>The track does not contain any obvious direct references to drug use.</li>
+			<li>The track does not contain any obvious sexual references, including suggestive sounds.</li>
+			<li>The track does not advocate crime or gun use (which is a criminal act in some countries).</li>
+		</ul>
+		<p>Obviously, not everyone agrees with this definition, and I don't upload every track. Some people will mark a track as being non-work-safe if it contains language they don't understand (in case it breaches one of the recommendations), or will mark a track as being work-or-family safe even if it breaches one of the above recommendations. If you disagree with how the track is marked, please feel free to contact <a href="mailto:show@cchits.net">show@cchits.net</a> and I'll re-listen to the track, and possibly change it's flag, if I think it's appropriate.</p>
+	</div>
+{/block}

--- a/TEMPLATES/Source/chart.html.tpl
+++ b/TEMPLATES/Source/chart.html.tpl
@@ -1,17 +1,20 @@
-<html>
-	<head>
-    <meta name=viewport content="width=device-width, initial-scale=1">
-		<link href="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jplayer.blue.monday.css" rel="stylesheet" type="text/css" />
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.min.js"></script>
-		<title>Chart: {$ServiceName} - {$Slogan}</title>
-	</head>
-	<body>
-                <h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
-		<h2>{$Slogan}</h2>
-		{if $previous_page == true}<a href="{$arrUri.no_params}{if isset($arrUri.parameters.page) and $arrUri.parameters.page - 1 > 0}?page={$arrUri.parameters.page - 1}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}{else}{if isset($arrUri.parameters.size)}?size={$arrUri.parameters.size}{/if}{/if}">&lt;- Previous page</a>{/if}
-		{if $next_page == true}<a href="{$arrUri.no_params}?page={if isset($arrUri.parameters.page)}{$arrUri.parameters.page + 1}{else}1{/if}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}">Next page -&gt;</a>{/if}
+{extends file="partials/_layout.html.tpl"}
+{block name=title}Chart: {$ServiceName} - {$Slogan}{/block}
+{block name=content}
+	
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.js"></script>
+	
+	<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
+	<h2>{$Slogan}</h2>
+		
+	{if $previous_page == true}
+			<a href="{$arrUri.no_params}{if isset($arrUri.parameters.page) and $arrUri.parameters.page - 1 > 0}?page={$arrUri.parameters.page - 1}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}{else}{if isset($arrUri.parameters.size)}?size={$arrUri.parameters.size}{/if}{/if}">&lt;- Previous page</a>
+	{/if}
+	{if $next_page == true}
+			<a href="{$arrUri.no_params}?page={if isset($arrUri.parameters.page)}{$arrUri.parameters.page + 1}{else}1{/if}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}">Next page -&gt;</a>
+	{/if}
 		<div id="chart">
 			<h3>The Chart for {$chart.strChartDate}</h3>
 			<table>
@@ -26,24 +29,32 @@
 					</tr>
 				</thead>
 				<tbody>
-{if isset($chart) and isset($chart.position)}
-{foreach from=$chart.position key=position item=track}
-{strip} 
-					<tr bgcolor="{cycle values="#eeeeee,#dddddd"}">
-						{include file="show_track_data.tpl"}
-				    </tr>
-{/strip}
-{/foreach}
-{/if}
+					{if isset($chart) and isset($chart.position)}
+						{foreach from=$chart.position key=position item=track}
+							{strip} 
+								<tr bgcolor="{cycle values="#eeeeee,#dddddd"}">
+									{include file="show_track_data.tpl"}
+								</tr>
+							{/strip}
+						{/foreach}
+					{/if}
 				</tbody>
 			</table>
 		</div>
-		{if $previous_page == true}<a href="{$arrUri.no_params}{if $arrUri.parameters.page - 1 > 0}?page={$arrUri.parameters.page - 1}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}{else}{if isset($arrUri.parameters.size)}?size={$arrUri.parameters.size}{/if}{/if}">&lt;- Previous page</a>{/if}
-		{if $next_page == true}<a href="{$arrUri.no_params}?page={$arrUri.parameters.page + 1}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}">Next page -&gt;</a>{/if}
-	</body>
+	{if $previous_page == true}
+			<a href="{$arrUri.no_params}{if isset($arrUri.parameters.page) and $arrUri.parameters.page - 1 > 0}?page={$arrUri.parameters.page - 1}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}{else}{if isset($arrUri.parameters.size)}?size={$arrUri.parameters.size}{/if}{/if}">&lt;- Previous page</a>
+	{/if}
+	{if $next_page == true}
+			<a href="{$arrUri.no_params}?page={if isset($arrUri.parameters.page)}{$arrUri.parameters.page + 1}{else}1{/if}{if isset($arrUri.parameters.size)}&size={$arrUri.parameters.size}{/if}">Next page -&gt;</a>
+	{/if}
+
+
 	<script type="text/javascript">
 		$(function() {
 			$('.inlinesparkline').sparkline();
-		});
+		}); 
 	</script>
-</html>
+
+
+
+{/block}

--- a/TEMPLATES/Source/partials/_layout.html.tpl
+++ b/TEMPLATES/Source/partials/_layout.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<title>{$ServiceName}</title>
+		<title>{block name=title}{$ServiceName}{/block}</title>
 		{if isset($ShowDaily)}
 			<link rel="alternate" type="application/rss+xml" href="{$baseURL}daily/rss" title="The {$ShowDaily}" />
 		{/if}
@@ -44,3 +44,8 @@
 				</nav>				
 			</div>
 		</div>
+        <div class="container">
+            {block name=content}{/block}
+        </div>
+    </body>
+</html>

--- a/TEMPLATES/Source/show.html.tpl
+++ b/TEMPLATES/Source/show.html.tpl
@@ -1,23 +1,22 @@
-<html>
-	<head>
-    <meta name=viewport content="width=device-width, initial-scale=1">
-		<link href="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jplayer.blue.monday.css" rel="stylesheet" type="text/css" />
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.min.js"></script>
-{if isset($playlist.player_data.mp3) or isset($playlist.player_data.oga) or isset($playlist.player_data.m4a)}{include file="player.js.tpl" player_id="1" playlist=$playlist_json}{/if}
-		<title>{$ServiceName} - {$Slogan}</title>
-	</head>
-	<body>
-                <h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
-		<h2>{$Slogan}</h2>
-		<h3><a href="{$show.strShowUrl}">{$show.strShowName}</a></h3>
-{if isset($playlist.player_data.mp3) or isset($playlist.player_data.oga) or isset($playlist.player_data.m4a)}{include file="player.html.tpl" player_id=$show.intShowID playlist=$show}{/if}
-{if isset($show.arrTracks) and count($show.arrTracks) > 0}
-{foreach from=$show.arrTracks item=track}
-		<form action="{$baseURL}vote/{$track.intTrackID}/{$show.intShowID}?go" method="post">
-			<p><a href="{$baseURL}track/{$track.intTrackID}"><img src="{$track.qrcode}" alt="QR Code for this track" /></a> "<a href="{$track.strTrackUrl}">{$track.strTrackName}</a>" by "<a href="{$track.strArtistUrl}">{$track.strArtistName}</a>" <input type="submit" name="go" value="I like this track!" /></p>
-		</form>
-{/foreach}
-{/if}
-	</body>
-</html>
+{extends file="partials/_layout.html.tpl"}
+{block name=title}About: {$ServiceName} - {$Slogan}{/block}
+{block name=content}
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.min.js"></script>
+	{if isset($playlist.player_data.mp3) or isset($playlist.player_data.oga) or isset($playlist.player_data.m4a)}
+		{include file="player.js.tpl" player_id="1" playlist=$playlist_json}
+	{/if}
+	<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
+	<h2>{$Slogan}</h2>
+	<h3><a href="{$show.strShowUrl}">{$show.strShowName}</a></h3>
+	{if isset($playlist.player_data.mp3) or isset($playlist.player_data.oga) or isset($playlist.player_data.m4a)}
+		{include file="player.html.tpl" player_id=$show.intShowID playlist=$show}
+	{/if}
+	{if isset($show.arrTracks) and count($show.arrTracks) > 0}
+		{foreach from=$show.arrTracks item=track}
+			<form action="{$baseURL}vote/{$track.intTrackID}/{$show.intShowID}?go" method="post">
+				<p><a href="{$baseURL}track/{$track.intTrackID}"><img src="{$track.qrcode}" alt="QR Code for this track" /></a> "<a href="{$track.strTrackUrl}">{$track.strTrackName}</a>" by "<a href="{$track.strArtistUrl}">{$track.strArtistName}</a>" <input type="submit" name="go" value="I like this track!" /></p>
+			</form>
+		{/foreach}
+	{/if}
+{/block}

--- a/TEMPLATES/Source/shows.html.tpl
+++ b/TEMPLATES/Source/shows.html.tpl
@@ -1,20 +1,17 @@
-<html>
-	<head>
-    <meta name=viewport content="width=device-width, initial-scale=1">
-		<link href="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jplayer.blue.monday.css" rel="stylesheet" type="text/css" />
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.min.js"></script>
-		<script type="text/javascript" src="{$baseURL}JAVASCRIPT/playlist.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.min.js"></script>
-		<script type="text/javascript">{literal}//<![CDATA[
-		$(document).ready(function() {{/literal}
+{extends file="partials/_layout.html.tpl"}
+{block name=title}{$ServiceName} - {$Slogan}{/block}
+{block name=content}
+	<link href="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jplayer.blue.monday.css" rel="stylesheet" type="text/css" />
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY/{$jquery}/jquery.min.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JPLAYER/{$jplayer}/jquery.jplayer.min.js"></script>
+	<script type="text/javascript" src="{$baseURL}JAVASCRIPT/playlist.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.min.js"></script>
+	<script type="text/javascript">{literal}//<![CDATA[
+	$(document).ready(function() {{/literal}
 			$('.inlinesparkline').sparkline();
 {include file="player.js.tpl" player_id=1 playlist=$playlist_json}
 		{literal}});{/literal}//]]></script>
-		<title>{$ServiceName} - {$Slogan}</title>
-	</head>
-	<body>
-                <h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
+		<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
 		<h2>{$Slogan}</h2>
 {include file="player.html.tpl" player_id=1 playlist=$shows}
 		{foreach from=$shows key=id item=show}
@@ -24,6 +21,9 @@
 			<p><img src="{$track.qrcode}" alt="QR Code for this page" /> "<a href="{$track.strTrackUrl}">{$track.strTrackName}</a>" by "<a href="{$track.strArtistUrl}">{$track.strArtistName}</a>" <input type="submit" name="go" value="I like this track!" /></p>
 		</form>
 		{/foreach}
-		{/foreach}
-	</body>
-</html>
+	{/foreach}
+{/block}
+
+ 
+
+

--- a/TEMPLATES/Source/track.html.tpl
+++ b/TEMPLATES/Source/track.html.tpl
@@ -1,73 +1,70 @@
-<!DOCTYPE html>
-<html>
-	<head>
-    <meta name=viewport content="width=device-width, initial-scale=1">
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY3/{$jquery3}/jquery.js"></script>
-		<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.js"></script>
-		<link rel="stylesheet" href="{$baseURL}EXTERNALS/BOOTSTRAP4/{$bootstrap4}/css/bootstrap.min.css" />
-		<link rel="stylesheet" href="{$baseURL}CSS/cchits.css" />
-		<link rel="stylesheet" href="{$baseURL}CSS/cchits-extra.css" />
-		<style>
-			.table {
+{extends file="partials/_layout.html.tpl"}
+{block name=title}{$ServiceName}{/block}
+{block name=content}
+	<!-- <meta name=viewport content="width=device-width, initial-scale=1"> -->
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY3/{$jquery3}/jquery.js"></script>
+	<script type="text/javascript" src="{$baseURL}EXTERNALS/JQUERY.SPARKLINE/{$jquerysparkline}/jquery.sparkline.js"></script>
+	<link rel="stylesheet" href="{$baseURL}EXTERNALS/BOOTSTRAP4/{$bootstrap4}/css/bootstrap.min.css" />
+	<link rel="stylesheet" href="{$baseURL}CSS/cchits.css" />
+	<link rel="stylesheet" href="{$baseURL}CSS/cchits-extra.css" />
+	<style>
+		.table {
 				width: initial;
-			}
-			a:hover {
+		}
+		a:hover {
 				background-color: initial;
 				color: initial;
 				text-decoration: underline;
-			}
-			a {
+		}
+		a {
 				text-decoration: underline;
-			}
-		</style>
-		<title>{$ServiceName}</title>
-	</head>
-	<body>
-	<div class="container-fluid">
+		}
+	</style>
 
-                <h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
+	<div class="container-fluid">
+		<h1><a href="{$baseURL}">Welcome to {$ServiceName}</a></h1>
 		<h2>{$Slogan}</h2>
-{if $user.isUploader}
-		<p><a href="{$baseURL}admin/track/{$track.intTrackID}">Edit track</a></p>
-{/if}
-{if $user.isAdmin}
-		<p><a href="{$baseURL}admin/show/?intTrackID={$track.intTrackID}">Add track to show</a></p>
-{/if}
-{if $track.isNSFW}
-		<p><a href="{$baseURL}about#nsfw">This track may not be suitable for family or office listening.</a></p>
-{/if}
-		<img src="{$track.qrcode}" alt="QR Code for this page" />
-		<h3>"<a href="{$track.strTrackUrl}">{$track.strTrackName}</a>" by "<a href="{$track.strArtistUrl}">{$track.strArtistName}</a>"</h3>
-		<div class="col-12 col-md-3">
-			<div class="row">
-				<div class="col col-player" id="single">
-					{include file="player2.html.tpl" player_id="1" playlist=$single_player_json}
+		{if $user.isUploader}
+			<p><a href="{$baseURL}admin/track/{$track.intTrackID}">Edit track</a></p>
+		{/if}
+		{if $user.isAdmin}
+			<p><a href="{$baseURL}admin/show/?intTrackID={$track.intTrackID}">Add track to show</a></p>
+		{/if}
+		{if $track.isNSFW}
+			<p><a href="{$baseURL}about#nsfw">This track may not be suitable for family or office listening.</a></p>
+		{/if}
+				<img src="{$track.qrcode}" alt="QR Code for this page" />
+				<h3>"<a href="{$track.strTrackUrl}">{$track.strTrackName}</a>" by "<a href="{$track.strArtistUrl}">{$track.strArtistName}</a>"</h3>
+				<div class="col-12 col-md-3">
+					<div class="row">
+						<div class="col col-player" id="single">
+							{include file="player2.html.tpl" player_id="1" playlist=$single_player_json}
+						</div>
+					</div>
 				</div>
-			</div>
-		</div>
-		<form action="{$baseURL}vote/{$track.intTrackID}?go" method="post">
-  			<input type="submit" name="go" value="I like this track!" />
-		</form>
-{if not $track.isNSFW}
-{if not $track.needsReview}
-		<form action="{$baseURL}report/{$track.intTrackID}?go" method="post">
-			<input type="submit" name="go" value="Report this track as not safe for family or work" />
-		</form>
-{else}
-		<div><b style="color: red">This track has been reported as not safe for family or work, it will be reviewed by a moderator.</b></div>
-{if $user.isAdmin}
-		<br/>
-		<form style="color: blue;" action="{$baseURL}review/{$track.intTrackID}?go" method="post">
-			<b>
-			Is this track safe for family or work ?
-			<input type="radio" name="isNSFW" value="no"> Yes
-			<input type="radio" name="isNSFW" value="yes" checked> No
-			<input type="submit" name="go" value="Review this track" />
-			</b>
-		</form>
-{/if}
-{/if}
-{/if}
+				<form action="{$baseURL}vote/{$track.intTrackID}?go" method="post">
+					<input type="submit" name="go" value="I like this track!" />
+				</form>
+		{if not $track.isNSFW}
+			{if not $track.needsReview}
+				<form action="{$baseURL}report/{$track.intTrackID}?go" method="post">
+					<input type="submit" name="go" value="Report this track as not safe for family or work" />
+				</form>
+			{else}
+				<div><b style="color: red">This track has been reported as not safe for family or work, it will be reviewed by a moderator.</b></div>
+				{if $user.isAdmin}
+					<br/>
+					<form style="color: blue;" action="{$baseURL}review/{$track.intTrackID}?go" method="post">
+						<b>
+							Is this track safe for family or work ?
+							<input type="radio" name="isNSFW" value="no"> Yes
+							<input type="radio" name="isNSFW" value="yes" checked> No
+							<input type="submit" name="go" value="Review this track" />
+						</b>
+					</form>
+				{/if}
+			{/if}
+		{/if}
 		{include file="track_detail.tpl"}
 	</div>
 		<script type="text/javascript">
@@ -83,5 +80,8 @@
 		<script src="{$baseURL}EXTERNALS/FONTAWESOME/{$fontawesome}/svg-with-js/js/fontawesome-all.js"></script>
 		<script src="{$baseURL}EXTERNALS/JPLAYER29/{$jplayer29}/jplayer/jquery.jplayer.js"></script>
 		<script src="{$baseURL}EXTERNALS/JPLAYER29/{$jplayer29}/add-on/jplayer.playlist.js"></script>
-	</body>
-</html>
+
+
+
+{/block}
+


### PR DESCRIPTION
I realise that @ymauray  is working on this - but I had a go, and thought this might be of interest.  

I started looking into this because I was getting warnings - found that header template was creating links for the rss feeds, and in certain situations (like the about page), these do not have the links for the rss feeds.  So I added isset checks on these variables.

I also tried an alternative approach with regard to templating - this approach uses block support from Smarty. 

The only other thing I noted was the https://cchits.net/chart has a reference to https://cchits.net/EXTERNALS/JQUERY.SPARKLINE/2.1.2/jquery.sparkline.min.js which doesn't exist.  If we alter that page to reference jquery.sparkline.js then the line charting works.

I've added underlining to links in the content container inline with the existing styling.

Noted that the next / previous button on the bottom of the chart page was different at the bottom of the page, from the top of the page.  It seems that pagination controls might be reusable - so perhaps these might be reusable.

If this is treading on toes / duplicating effort I'm sorry - and I'd totally understand if this PR is rejected.