### PR TITLE
String formatting

### DIFF
--- a/CLASSES/class_API.php
+++ b/CLASSES/class_API.php
@@ -747,6 +747,6 @@ class API
  */
 class API_NotApiCall extends CustomException
 {
-    protected $message = "This is not an API call. Please see https:\/\/github.com\/CCHits\/Website\/wiki\/Using-the-API for details on the API";
+    protected $message = "This is not an API call. Please see https://github.com/CCHits/Website/wiki/Using-the-API for details on the API";
     protected $code    = 255;
 }


### PR DESCRIPTION
On my system, the multi-line text and the unescaped slashes caused a real problem trying to run the monthly show.  So by merging the lines, and using double-quotes, it appears to have resolved the issue.

The timing of the previous change to this file - February 2018 - just seems a little too close to when the last successful monthly file was - March 2018.