### PR TITLE
Fix show long description and Vote Adjust link

### DIFF
--- a/CLASSES/class_ArtistObject.php
+++ b/CLASSES/class_ArtistObject.php
@@ -111,7 +111,7 @@ class ArtistObject extends GenericObject
      */
     function get_strArtistName()
     {
-        return $this->strArtistName;
+        return $this->preferredJson($this->strArtistName);
     }
 
     /**

--- a/CLASSES/class_TrackObject.php
+++ b/CLASSES/class_TrackObject.php
@@ -761,7 +761,7 @@ class TrackObject extends GenericObject
      */
     function get_strTrackName()
     {
-        return $this->strTrackName;
+        return $this->preferredJson($this->strTrackName);
     }
 
     /**

--- a/TEMPLATES/Source/track_detail.tpl
+++ b/TEMPLATES/Source/track_detail.tpl
@@ -1,4 +1,4 @@
-		<p>This track has {$track.decVoteAdj} adjusted votes since {$track.dtsAdded}, which is <a href="{$baseURL}about#voteadj">{$track.decAdj * 100}% of</a> {$track.intVote} votes.</p>
+		<p>This track has {$track.decVoteAdj} adjusted votes since {$track.dtsAdded}, which is <a href="{$baseURL}about#voteadjust">{$track.decAdj * 100}% of</a> {$track.intVote} votes.</p>
 		<p class="chart_movement">The track is at position {$track.arrChartData.0.intPositionID}, which is {if $track.strPositionYesterday == 'equal'}the same as{elseif $track.strPositionYesterday == 'up'}up from{else}down from{/if} yesterday's chart position. On a week-by-week average, the track is {if $track.strPositionLastWeek == 'equal'}the same as{elseif $track.strPositionLastWeek == 'up'}up from{else}down from{/if} last week's position.</p> 
 		<p class="chart_positions">Chart positions: {include file='sparkline.tpl'}</p>
 		<p>If you want to download this file, please visit the link to the track above. If that link is not working, you can download it <a href="{$track.localSource}">here</a>.</p>

--- a/TEMPLATES/Source/track_detail.tpl
+++ b/TEMPLATES/Source/track_detail.tpl
@@ -18,7 +18,7 @@
 {strip} 
 					<tr class="shows {cycle values="row_odd,row_even"}{if not $smarty.foreach.shows.first and $smarty.foreach.shows.iteration <= $smarty.foreach.shows.total - 3} more_rows{/if}">
 				    	<td>{if isset($showData.intShowID)}<a href="{$baseURL}show/{$showData.intShowID}">{/if}<span class="{$showData.enumShowType}">{$showData.strShowName}</span>{if isset($showData.intShowID)}</a>{/if}</td>
-				    	<td>{$showData.decVoteAdj} (<a href="{$baseURL}about#voteadj">{$track.decAdj * 100}% of</a> {$showData.intVote})</td>
+				    	<td>{$showData.decVoteAdj} (<a href="{$baseURL}about#voteadjust">{$track.decAdj * 100}% of</a> {$showData.intVote})</td>
 				    </tr>
 {/strip}
 {/foreach}


### PR DESCRIPTION
# 1. Fix show long description in players

This one fixes the long show description that appears in the players, where the JSON array for the ArtistName and TrackName were being presented back to the UI.  This fix wraps the preferredJson() function around them to only return the preferred version of those values.

Example, look at https://cchits.net/daily - the entry for 2021-05-06 says:

```
The CCHits.net Daily Exposure Show for 2021-05-06 featuring ["Look What You've Got"] by ["KingSizeNine"] (mp3 | ogg | link)
```

and for 2021-04-30:

```
The CCHits.net Daily Exposure Show for 2021-04-30 featuring ["Never A Day","Never a Day"] by ["The Hedgerow Folk"] (mp3 | ogg | link)
```

This fix removes the array elements and selects the correct value.

# 2. Fix Vote Adjustment link on track page

This fix updates the track_detail.tpl template to change the #voteadj link to #voteadjust